### PR TITLE
invokable with custom arguments

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use League\Container\Definition\CallableDefinitionInterface;
 use League\Container\Definition\ClassDefinition;
 use League\Container\Definition\DefinitionInterface;
+use League\Container\Definition\Factory;
 use League\Container\Definition\FactoryInterface;
 
 class Container implements ContainerInterface
@@ -48,7 +49,7 @@ class Container implements ContainerInterface
      */
     public function __construct($config = [], FactoryInterface $factory = null)
     {
-        $this->factory = (is_null($factory)) ? new Definition\Factory : $factory;
+        $this->factory = (is_null($factory)) ? new Factory() : $factory;
 
         $this->addItemsFromConfig($config);
 
@@ -125,7 +126,7 @@ class Container implements ContainerInterface
     public function inflector($type, callable $callback = null)
     {
         if (is_null($callback)) {
-            $inflector = new Inflector;
+            $inflector = new Inflector();
             $this->inflectors[$type] = $inflector;
 
             return $inflector;
@@ -306,7 +307,7 @@ class Container implements ContainerInterface
     /**
      * Encapsulate the definition factory to allow for invokation
      *
-     * @return \League\Container\Definition\Factory
+     * @return \League\Container\Definition\FactoryInterface
      */
     protected function getDefinitionFactory()
     {

--- a/src/Container.php
+++ b/src/Container.php
@@ -3,7 +3,7 @@
 namespace League\Container;
 
 use ArrayAccess;
-use League\Container\Definition\CallableDefinition;
+use League\Container\Definition\CallableDefinitionInterface;
 use League\Container\Definition\ClassDefinition;
 use League\Container\Definition\DefinitionInterface;
 use League\Container\Definition\FactoryInterface;
@@ -245,7 +245,7 @@ class Container implements ContainerInterface
         $definition = $this->items[$alias]['definition'];
         $return     = $definition;
 
-        if ($definition instanceof CallableDefinition || $definition instanceof ClassDefinition) {
+        if ($definition instanceof CallableDefinitionInterface || $definition instanceof ClassDefinition) {
             $return = $definition($args);
         }
 

--- a/src/Definition/CallableDefinition.php
+++ b/src/Definition/CallableDefinition.php
@@ -1,22 +1,16 @@
 <?php
-
 namespace League\Container\Definition;
 
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 use League\Container\ContainerInterface;
-use ReflectionFunction;
-use ReflectionMethod;
-use ReflectionParameter;
 
-class CallableDefinition extends AbstractDefinition implements DefinitionInterface, ContainerAwareInterface
+class CallableDefinition extends AbstractDefinition implements
+    CallableDefinitionInterface,
+    DefinitionInterface,
+    ContainerAwareInterface
 {
     use ContainerAwareTrait;
-
-    /**
-     * @var callable
-     */
-    protected $callable;
 
     /**
      * Constructor
@@ -33,7 +27,11 @@ class CallableDefinition extends AbstractDefinition implements DefinitionInterfa
     }
 
     /**
-     * {@inheritdoc}
+     * Handle instantiation and manipulation of value and return
+     *
+     * @param array $args
+     *
+     * @return mixed
      */
     public function __invoke(array $args = [])
     {
@@ -46,34 +44,10 @@ class CallableDefinition extends AbstractDefinition implements DefinitionInterfa
             $this->callable[0] = ($registered) ? $this->container->get($this->callable[0]) : $this->callable[0];
         }
 
-        $resolved = $this->resolveArguments($this->arguments);
+        $args = (empty($args)) ? $this->arguments : $args;
 
-        if ($args) {
-            $names = $this->getArgumentNames($this->callable);
-
-            $resolved = array_combine(array_splice($names, 0, count($resolved)), $resolved);
-
-            return $this->container->call($this->callable, array_merge($resolved, $args));
-        }
+        $resolved = $this->resolveArguments($args);
 
         return call_user_func_array($this->callable, $resolved);
-    }
-
-    /**
-     * @param callable $callable
-     *
-     * @return array
-     */
-    protected function getArgumentNames(callable $callable)
-    {
-        if (is_array($callable)) {
-            $reflector = new ReflectionMethod($callable[0], $callable[1]);
-        } else {
-            $reflector = new ReflectionFunction($callable);
-        }
-
-        return array_map(function (ReflectionParameter $param) {
-            return $param->getName();
-        }, $reflector->getParameters());
     }
 }

--- a/src/Definition/CallableDefinitionInterface.php
+++ b/src/Definition/CallableDefinitionInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace League\Container\Definition;
+
+interface CallableDefinitionInterface
+{
+}

--- a/src/Definition/DefinitionInterface.php
+++ b/src/Definition/DefinitionInterface.php
@@ -5,7 +5,7 @@ namespace League\Container\Definition;
 interface DefinitionInterface
 {
     /**
-     * Handle instansiation and manipulation of value and return
+     * Handle instantiation and manipulation of value and return
      *
      * @param  array $args
      * @return mixed

--- a/src/Definition/Factory.php
+++ b/src/Definition/Factory.php
@@ -11,8 +11,12 @@ class Factory implements FactoryInterface
      */
     public function __invoke($alias, $concrete, ContainerInterface $container, $callable = false)
     {
-        if ($concrete instanceof \Closure || $callable === true) {
-            return new CallableDefinition($alias, $concrete, $container);
+        if (is_callable($concrete)) {
+            if ($callable) {
+                return new InvokableDefinition($alias, $concrete, $container);
+            } else {
+                return new CallableDefinition($alias, $concrete, $container);
+            }
         }
 
         if (is_string($concrete) && class_exists($concrete)) {

--- a/src/Definition/InvokableDefinition.php
+++ b/src/Definition/InvokableDefinition.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace League\Container\Definition;
+
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use League\Container\ContainerInterface;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionParameter;
+
+class InvokableDefinition extends AbstractDefinition implements
+    CallableDefinitionInterface,
+    DefinitionInterface,
+    ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var callable
+     */
+    protected $callable;
+
+    /**
+     * @var array
+     */
+    protected $argumentNames;
+
+    /**
+     * Constructor
+     *
+     * @param string                               $alias
+     * @param string|callable                      $concrete
+     * @param \League\Container\ContainerInterface $container
+     */
+    public function __construct($alias, $concrete, ContainerInterface $container = null)
+    {
+        parent::__construct($alias, $container);
+
+        $this->callable = $concrete;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke(array $args = [])
+    {
+        if (is_array($this->callable) && is_string($this->callable[0])) {
+            $registered = (
+                isset($this->container[$this->callable[0]]) ||
+                class_exists($this->callable[0])
+            );
+
+            $this->callable[0] = ($registered) ? $this->container->get($this->callable[0]) : $this->callable[0];
+        }
+
+        $resolved = $this->resolveArguments($this->arguments);
+
+        if ($args) {
+            if (is_null($this->argumentNames)) {
+                $this->argumentNames = $this->getArgumentNames($this->callable);
+            }
+
+            $resolved = array_combine(array_splice($this->argumentNames, 0, count($resolved)), $resolved);
+
+            return $this->container->call($this->callable, array_merge($resolved, $args));
+        }
+
+        return call_user_func_array($this->callable, $resolved);
+    }
+
+    /**
+     * @param callable $callable
+     *
+     * @return array
+     */
+    protected function getArgumentNames(callable $callable)
+    {
+        if (is_array($callable)) {
+            $reflector = new ReflectionMethod($callable[0], $callable[1]);
+        } else {
+            $reflector = new ReflectionFunction($callable);
+        }
+
+        return array_map(function (ReflectionParameter $param) {
+            return $param->getName();
+        }, $reflector->getParameters());
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -777,4 +777,23 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(123, $c->get('a_key'));
     }
+
+    public function testRegisteredCallableIsPassedArguments()
+    {
+        $c = new Container();
+
+        $c->add('alias', function ($arg1, $arg2, $arg3 = 'default') {
+            $obj = new \stdClass();
+            $obj->first = $arg1;
+            $obj->second = $arg2;
+            $obj->third = $arg3;
+            return $obj;
+        });
+
+        $obj = $c->get('alias', ['value 1', 'second']);
+
+        $this->assertEquals($obj->first, 'value 1');
+        $this->assertEquals($obj->second, 'second');
+        $this->assertEquals($obj->third, 'default');
+    }
 }


### PR DESCRIPTION
I assumed nobody used this:

```php
$container->invokable('closure', function ($arg1, $arg2) {
   ...
});

$container->call('closure', ['value1', 'value2']);
```

But this is backwards compatible:

```php
$container->add('item', function ($arg) {
   return $arg;
})->withArguments('default_value');

echo $container->get('item');
// 'default_value'

echo $container->get('item', ['override']);
// 'override'
```

Fixes #32.