### PR TITLE
Feature/pass args on newly reflected class.  Fixes #38

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -207,7 +207,7 @@ class Container implements ContainerInterface, ArrayAccess
 
         $this->items[$alias]['definition'] = $definition;
 
-        return $this->applyInflectors($definition());
+        return $this->applyInflectors($definition($args));
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -789,4 +789,15 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(123, $c->get('a_key'));
     }
+
+    public function testArgsArePassedToNewlyReflectedClasses()
+    {
+        $expected = 'Jimmy Puckett';
+
+        $c = new Container();
+
+        $f = $c->get('League\Container\Test\Asset\FooWithDefaultArg', [$expected]);
+
+        $this->assertEquals($expected, $f->name);
+    }
 }


### PR DESCRIPTION
The args var was missing from the newly reflected class, so just adding it to the call.