### PR TITLE
Update CallableDefinition.php

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,3 @@
 # Path-based git attributes
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
-# Ignore all test and documentation with "export-ignore".
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
-/tests              export-ignore

--- a/src/Definition/CallableDefinition.php
+++ b/src/Definition/CallableDefinition.php
@@ -48,6 +48,6 @@ class CallableDefinition extends AbstractDefinition implements DefinitionInterfa
             $this->callable[0] = ($registered === true) ? $this->container->get($this->callable[0]) : $this->callable[0];
         }
 
-        return call_user_func_array($this->callable, $resolved);
+        $this->container->call($this->callable, $resolved);
     }
 }


### PR DESCRIPTION
allow service provider closures to specify injectable dependencies. For example:

## service provider

```php

$this->getContainer( )->add( 'Blog\\Posts\\Author' , function( Container $container, Dispatcher $dispatcher ) <<<----
{
    return new FlatFileAuthor( $dispatcher, $container->get( 'storage path' ) . '/database/flatfile/posts.txt' );
});