### PR TITLE
Fix: Move build steps to appropriate sections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,13 @@ matrix:
 
 before_script:
   - travis_retry composer self-update
+
+install:
   - travis_retry composer install --no-interaction --prefer-source --dev
 
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
-after_script:
+after_success:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
This PR

* [x] updates composer itself in the `before_install` section
* [x] installs dependencies in the `install` section
* [x] uploads coverage in the `after_success` section (as there's no need to upload coverage when the build failed)