### PR TITLE
Enhancement: Allow to finish the build fast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ php:
   - 5.6
   - hhvm
 
+matrix:
+  fast_finish: true
+
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev


### PR DESCRIPTION
This PR

* [x] will mark the build as failed as soon as one of the builds has failed, because nobody ain't got time to wait these extra seconds