### PR TITLE
Fix: Add missing leading slash

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -445,7 +445,7 @@ class Container implements ContainerInterface, ArrayAccess
      * Get a reflection object for this callable.
      *
      * @param  callable $callable
-     * @return ReflectionFunctionAbstract
+     * @return \ReflectionFunctionAbstract
      */
     protected function reflectCallable(callable $callable)
     {


### PR DESCRIPTION
This PR

* [x] adds a missing leading slash as class `ReflectionFunctionAbstract` doesn't exist in the current namespace