### PR TITLE
Fix: Add missing import to ServiceProviderInterface

### DIFF
--- a/src/ServiceProvider/ServiceProviderInterface.php
+++ b/src/ServiceProvider/ServiceProviderInterface.php
@@ -2,6 +2,8 @@
 
 namespace League\Container\ServiceProvider;
 
+use League\Container\ContainerAwareInterface;
+
 interface ServiceProviderInterface extends ContainerAwareInterface
 {
     /**

--- a/tests/ServiceProvider/ServiceProviderInterfaceTest.php
+++ b/tests/ServiceProvider/ServiceProviderInterfaceTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace League\Container\Test\ServiceProvider;
+
+use League\Container\ContainerAwareInterface;
+use League\Container\ServiceProvider\ServiceProviderInterface;
+
+class ServiceProviderInterfaceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExtendsContainerAwareInterface()
+    {
+        $reflection = new \ReflectionClass(ServiceProviderInterface::class);
+
+        $this->assertTrue($reflection->implementsInterface(ContainerAwareInterface::class));
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that the `ServiceProviderInterface` extends the `ContainerAwareInterface` :trollface: 
* [x] fixes the build by adding a missing import