### PR TITLE
Fix: DefinitionFactoryInterface needs to extend ImmutableContainerAwareInterface

### DIFF
--- a/src/Definition/DefinitionFactory.php
+++ b/src/Definition/DefinitionFactory.php
@@ -2,10 +2,9 @@
 
 namespace League\Container\Definition;
 
-use League\Container\ImmutableContainerAwareInterface;
 use League\Container\ImmutableContainerAwareTrait;
 
-class DefinitionFactory implements DefinitionFactoryInterface, ImmutableContainerAwareInterface
+class DefinitionFactory implements DefinitionFactoryInterface
 {
     use ImmutableContainerAwareTrait;
 

--- a/src/Definition/DefinitionFactoryInterface.php
+++ b/src/Definition/DefinitionFactoryInterface.php
@@ -2,7 +2,9 @@
 
 namespace League\Container\Definition;
 
-interface DefinitionFactoryInterface
+use League\Container\ImmutableContainerAwareInterface;
+
+interface DefinitionFactoryInterface extends ImmutableContainerAwareInterface
 {
     /**
      * Return a definition based on type of concrete.


### PR DESCRIPTION
This PR

* [x] makes `DefinitionFactoryInterface` extend the `ImmutableContainerAwareInterface` because otherwise you wouldn't be able to set the container on an implementation of `DefinitionFactoryInterface`

See https://github.com/thephpleague/container/blob/master/src/Container.php#L68.