### PR TITLE
Fix: Undefined class

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -205,7 +205,7 @@ class Container implements ContainerInterface
      * cannot be resolved via this container.
      *
      * @param  \League\Container\ImmutableContainerInterface $container
-     * @return \League\Container\Container
+     * @return $this
      */
     public function stack(ImmutableContainerInterface $container)
     {

--- a/src/ContainerAwareTrait.php
+++ b/src/ContainerAwareTrait.php
@@ -13,7 +13,7 @@ trait ContainerAwareTrait
      * Set a container.
      *
      * @param  \League\Container\ContainerInterface $container
-     * @return mixed
+     * @return $this
      */
     public function setContainer(ContainerInterface $container)
     {

--- a/src/Definition/ClassDefinitionInterface.php
+++ b/src/Definition/ClassDefinitionInterface.php
@@ -9,7 +9,7 @@ interface ClassDefinitionInterface extends DefinitionInterface
      *
      * @param  string $method
      * @param  array  $args
-     * @return \League\Container\Definition\ClassDefinitionInterface
+     * @return $this
      */
     public function withMethodCall($method, array $args = []);
 
@@ -17,7 +17,7 @@ interface ClassDefinitionInterface extends DefinitionInterface
      * Add multiple methods to be invoked
      *
      * @param  array $methods
-     * @return \League\Container\Definition\ClassDefinitionInterface
+     * @return $this
      */
     public function withMethodCalls(array $methods = []);
 }

--- a/src/Definition/DefinitionInterface.php
+++ b/src/Definition/DefinitionInterface.php
@@ -16,7 +16,7 @@ interface DefinitionInterface
      * Add an argument to be injected.
      *
      * @param  mixed $arg
-     * @return \League\Container\Definition\DefinitionInterface
+     * @return $this
      */
     public function withArgument($arg);
 
@@ -24,7 +24,7 @@ interface DefinitionInterface
      * Add multiple arguments to be injected.
      *
      * @param  array $args
-     * @return \League\Container\Definition\DefinitionInterface
+     * @return $this
      */
     public function withArguments(array $args);
 }

--- a/src/ImmutableContainerAwareTrait.php
+++ b/src/ImmutableContainerAwareTrait.php
@@ -13,7 +13,7 @@ trait ImmutableContainerAwareTrait
      * Set a container.
      *
      * @param  \League\Container\ImmutableContainerInterface $container
-     * @return mixed
+     * @return $this
      */
     public function setContainer(ImmutableContainerInterface $container)
     {

--- a/src/Inflector/Inflector.php
+++ b/src/Inflector/Inflector.php
@@ -26,7 +26,7 @@ class Inflector implements ArgumentResolverInterface
      *
      * @param  string $name
      * @param  array  $args
-     * @return \League\Container\Inflector
+     * @return $this
      */
     public function invokeMethod($name, array $args)
     {
@@ -39,7 +39,7 @@ class Inflector implements ArgumentResolverInterface
      * Defines multiple methods to be invoked on the subject object.
      *
      * @param  array $methods
-     * @return \League\Container\Inflector
+     * @return $this
      */
     public function invokeMethods(array $methods)
     {
@@ -55,7 +55,7 @@ class Inflector implements ArgumentResolverInterface
      *
      * @param  string $property
      * @param  mixed  $value
-     * @return \League\Container\Inflector
+     * @return $this
      */
     public function setProperty($property, $value)
     {
@@ -68,7 +68,7 @@ class Inflector implements ArgumentResolverInterface
      * Defines multiple properties to be set on the subject object.
      *
      * @param  array $properties
-     * @return \League\Container\Inflector
+     * @return $this
      */
     public function setProperties(array $properties)
     {

--- a/src/ServiceProvider/ServiceProviderAggregateInterface.php
+++ b/src/ServiceProvider/ServiceProviderAggregateInterface.php
@@ -10,7 +10,7 @@ interface ServiceProviderAggregateInterface extends ContainerAwareInterface
      * Add a service provider to the aggregate.
      *
      * @param  string|\League\Container\ServiceProvider\ServiceProviderInterface $provider
-     * @return \League\Container\ServiceProvider\ServiceProviderAggregateInterface
+     * @return $this
      */
     public function add($provider);
 


### PR DESCRIPTION
This PR

* [x] fixes doblocks which claim to return `League\Container\Inflector`, which probably should be `League\Container\Inflector\Inflector` instead, but actually, the same instance is returned