### PR TITLE
Fix: AbstractDefinition should implement DefinitionInterface

### DIFF
--- a/src/Definition/AbstractDefinition.php
+++ b/src/Definition/AbstractDefinition.php
@@ -6,7 +6,7 @@ use League\Container\Argument\ArgumentResolverInterface;
 use League\Container\Argument\ArgumentResolverTrait;
 use League\Container\ImmutableContainerAwareTrait;
 
-abstract class AbstractDefinition implements ArgumentResolverInterface
+abstract class AbstractDefinition implements ArgumentResolverInterface, DefinitionInterface
 {
     use ArgumentResolverTrait;
     use ImmutableContainerAwareTrait;

--- a/src/Definition/CallableDefinition.php
+++ b/src/Definition/CallableDefinition.php
@@ -2,7 +2,7 @@
 
 namespace League\Container\Definition;
 
-class CallableDefinition extends AbstractDefinition implements DefinitionInterface
+class CallableDefinition extends AbstractDefinition
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This PR

* [x] makes `AbstractDefinition` implement the `DefinitionInterface`

Follows https://github.com/thephpleague/container/pull/65#issuecomment-134236024.