### PR TITLE
Fix: Docblock

### DIFF
--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -7,9 +7,9 @@ interface ContainerInterface extends ImmutableContainerInterface
     /**
      * Add an item to the container.
      *
-     * @param  string|\League\Container\ServiceProvider $alias
-     * @param  mixed|null                               $concrete
-     * @param  boolean                                  $share
+     * @param  string|\League\Container\ServiceProvider\ServiceProviderInterface $alias
+     * @param  mixed|null                                                        $concrete
+     * @param  boolean                                                           $share
      * @return \League\Container\Definition\DefinitionInterface
      */
     public function add($alias, $concrete = null, $share = false);


### PR DESCRIPTION
This PR

* [x] fixes a docblock, where the argument should implement `League\Container\ServiceProvider\ServiceProviderInterface`, rather than being an instance of `League\Container\ServiceProvider`, which doesn't exist