### PR TITLE
Fix: Trait can't inherit docblock

### DIFF
--- a/src/Argument/ArgumentResolverTrait.php
+++ b/src/Argument/ArgumentResolverTrait.php
@@ -3,6 +3,7 @@
 namespace League\Container\Argument;
 
 use InvalidArgumentException;
+use League\Container\ContainerInterface;
 use ReflectionFunctionAbstract;
 use ReflectionParameter;
 
@@ -59,7 +60,7 @@ trait ArgumentResolverTrait
     }
 
     /**
-     * {@inheritdoc}
+     * @return ContainerInterface
      */
     abstract public function getContainer();
 }


### PR DESCRIPTION
This PR

* [x] fixes a docblock in a trait, which claims to inherit documentation, but technically can't