### PR TITLE
Fix: Assert that container iterates stack

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -107,13 +107,7 @@ class Container implements ContainerInterface
             return true;
         }
 
-        foreach ($this->stack as $container) {
-            if ($container->has($alias)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->hasInStack($alias);
     }
 
     /**
@@ -212,6 +206,23 @@ class Container implements ContainerInterface
         $this->stack[] = $container;
 
         return $this;
+    }
+
+    /**
+     * Returns true if service is registered in one of the backup containers.
+     *
+     * @param  string $alias
+     * @return bool
+     */
+    protected function hasInStack($alias)
+    {
+        foreach ($this->stack as $container) {
+            if ($container->has($alias)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] asserts that the container iterates over the stacked containers to see if an item for `$alias` is registered
* [x] asserts that the container iterates over the stacked containers to fetch an item for `$alias`
* [x] extracts a method `hasInStack($alias)`, similar to `getFromStack($alias, $args)`