### PR TITLE
Fix: Add coverage for ReflectionContainer, fix bugs

### DIFF
--- a/src/Argument/ArgumentResolverTrait.php
+++ b/src/Argument/ArgumentResolverTrait.php
@@ -3,6 +3,7 @@
 namespace League\Container\Argument;
 
 use InvalidArgumentException;
+use League\Container\ReflectionContainer;
 use ReflectionFunctionAbstract;
 use ReflectionParameter;
 
@@ -19,8 +20,17 @@ trait ArgumentResolverTrait
                 continue;
             }
 
-            if (is_string($arg) && ($this->getContainer()->has($arg) || class_exists($arg))) {
-                $arg = $this->getContainer()->get($arg);
+            if (!is_string($arg)) {
+                 continue;
+            }
+
+            $container = $this->getContainer();
+            if (!$container && $this instanceof ReflectionContainer) {
+                $container = $this;
+            }
+
+            if ($container && $container->has($arg)) {
+                $arg = $container->get($arg);
             }
         }
 

--- a/src/ReflectionContainer.php
+++ b/src/ReflectionContainer.php
@@ -11,7 +11,6 @@ use ReflectionMethod;
 
 class ReflectionContainer implements
     ArgumentResolverInterface,
-    ImmutableContainerAwareInterface,
     ImmutableContainerInterface
 {
     use ArgumentResolverTrait;

--- a/src/ReflectionContainer.php
+++ b/src/ReflectionContainer.php
@@ -28,6 +28,10 @@ class ReflectionContainer implements
             return new $alias;
         }
 
+        if ($construct === null) {
+            return new $alias;
+        }
+
         return $reflector->newInstanceArgs(
             $this->reflectArguments($construct, $args)
         );

--- a/tests/ReflectionContainerTest.php
+++ b/tests/ReflectionContainerTest.php
@@ -2,6 +2,7 @@
 
 namespace League\Container\Test;
 
+use League\Container\ImmutableContainerInterface;
 use League\Container\ReflectionContainer;
 
 class ReflectionContainerTest extends \PHPUnit_Framework_TestCase
@@ -36,5 +37,92 @@ class ReflectionContainerTest extends \PHPUnit_Framework_TestCase
         $container = new ReflectionContainer();
 
         $this->assertInstanceOf($classWithoutConstructor, $container->get($classWithoutConstructor));
+    }
+
+    /**
+     * Asserts that ReflectionContainer instantiates a class that has a constructor.
+     */
+    public function testGetInstantiatesClassWithConstructor()
+    {
+        $classWithConstructor = 'League\Container\Test\Asset\Foo';
+        $dependencyClass = 'League\Container\Test\Asset\Bar';
+
+        $container = new ReflectionContainer();
+
+        $item = $container->get($classWithConstructor);
+
+        $this->assertInstanceOf($classWithConstructor, $item);
+        $this->assertInstanceOf($dependencyClass, $item->bar);
+    }
+
+    /**
+     * Asserts that ReflectionContainer instantiates a class that has a constructor with a type-hinted argument, and
+     * fetches that dependency from the container injected into the ReflectionContainer.
+     */
+    public function testGetInstantiatesClassWithConstructorAndUsesContainer()
+    {
+        $classWithConstructor = 'League\Container\Test\Asset\Foo';
+        $dependencyClass = 'League\Container\Test\Asset\Bar';
+        $dependency = new $dependencyClass;
+
+        $container = new ReflectionContainer();
+
+        $container->setContainer($this->getImmutableContainerMock([
+            $dependencyClass => $dependency,
+        ]));
+
+        $item = $container->get($classWithConstructor);
+
+        $this->assertInstanceOf($classWithConstructor, $item);
+        $this->assertSame($dependency, $item->bar);
+    }
+
+    /**
+     * Asserts that ReflectionContainer instantiates a class that has a constructor with a type-hinted argument, and
+     * uses the values provided in the argument array.
+     */
+    public function testGetInstantiatesClassWithConstructorAndUsesArguments()
+    {
+        $classWithConstructor = 'League\Container\Test\Asset\Foo';
+        $dependencyClass = 'League\Container\Test\Asset\Bar';
+        $dependency = new $dependencyClass;
+
+        $container = new ReflectionContainer();
+
+        $item = $container->get($classWithConstructor, [
+            'bar' => $dependency,
+        ]);
+
+        $this->assertInstanceOf($classWithConstructor, $item);
+        $this->assertSame($dependency, $item->bar);
+    }
+
+    /**
+     * @param array $items
+     * @return \PHPUnit_Framework_MockObject_MockObject|ImmutableContainerInterface
+     */
+    private function getImmutableContainerMock(array $items = [])
+    {
+        $container = $this->getMockBuilder('League\Container\ImmutableContainerInterface')->getMock();
+
+        $container
+            ->expects($this->any())
+            ->method('has')
+            ->willReturnCallback(function ($alias) use ($items) {
+                return array_key_exists($alias, $items);
+            })
+        ;
+
+        $container
+            ->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($alias) use ($items) {
+                if (array_key_exists($alias, $items)) {
+                    return $items[$alias];
+                }
+            })
+        ;
+
+        return $container;
     }
 }

--- a/tests/ReflectionContainerTest.php
+++ b/tests/ReflectionContainerTest.php
@@ -25,4 +25,16 @@ class ReflectionContainerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($container->has('Foo\Bar\Baz'));
     }
+
+    /**
+     * Asserts that ReflectionContainer instantiates a class that does not have a constructor.
+     */
+    public function testGetInstantiatesClassWithoutConstructor()
+    {
+        $classWithoutConstructor = 'League\Container\Test\Asset\Bar';
+
+        $container = new ReflectionContainer();
+
+        $this->assertInstanceOf($classWithoutConstructor, $container->get($classWithoutConstructor));
+    }
 }

--- a/tests/ReflectionContainerTest.php
+++ b/tests/ReflectionContainerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace League\Container\Test;
+
+use League\Container\ReflectionContainer;
+
+class ReflectionContainerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Asserts that ReflectionContainer claims it has an item if a class exists for the alias.
+     */
+    public function testHasReturnsTrueIfClassExists()
+    {
+        $container = new ReflectionContainer();
+
+        $this->assertTrue($container->has('League\Container\Test\Asset\Bar'));
+    }
+
+    /**
+     * Asserts that ReflectionContainer denies it has an item if a class does not exist for the alias.
+     */
+    public function testHasReturnsFalseIfClassDoesNotExist()
+    {
+        $container = new ReflectionContainer();
+
+        $this->assertFalse($container->has('Foo\Bar\Baz'));
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that `ReflectionContainer` checks if class exists
* [x] removes the previously implemented `ImmutableContainerAwareInterface`
* [x] asserts that `ReflectionContainer` instantiates class without constructor
* [x] returns an instance of the class if it doesn't have a constructor
* [x] asserts that `ReflectionContainer` instantiates class with constructor
* [x] fetches dependency from injected container or self
