### PR TITLE
Fix: Allow items to be shared

### DIFF
--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -103,6 +103,24 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Asserts that fetching a shared item always returns the same item.
+     */
+    public function testGetSharedItemReturnsTheSameItem()
+    {
+        $alias = 'foo';
+
+        $container = new Container;
+
+        $container->share($alias, function () {
+            return new \stdClass;
+        });
+
+        $item = $container->get($alias);
+
+        $this->assertSame($item, $container->get($alias));
+    }
+
+    /**
      * @param array $items
      * @return \PHPUnit_Framework_MockObject_MockObject|ImmutableContainerInterface
      */


### PR DESCRIPTION
This PR

* [x] asserts that items can be shared
* [x] stores shared definitions separately in `$sharedDefinitions`, and stores the result of building a shared definition in `$stored`

:person_with_pouting_face: Not sure if the removal was intended, but currently doesn't work as expected.