### PR TITLE
Fix: Assert that has() returns true for shared definition

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -84,7 +84,7 @@ class Container implements ContainerInterface
             return $this->inflectors->inflect($this->shared[$alias]);
         }
 
-        if ($this->hasSharedDefinition($alias)) {
+        if (array_key_exists($alias, $this->sharedDefinitions)) {
             $shared = $this->inflectors->inflect($this->sharedDefinitions[$alias]->build());
             $this->shared[$alias] = $shared;
             return $shared;
@@ -114,7 +114,10 @@ class Container implements ContainerInterface
      */
     public function has($alias)
     {
-        if (array_key_exists($alias, $this->definitions) || $this->hasShared($alias)) {
+        if (array_key_exists($alias, $this->definitions)
+            || array_key_exists($alias, $this->sharedDefinitions)
+            || $this->hasShared($alias)
+        ) {
             return true;
         }
 
@@ -134,17 +137,6 @@ class Container implements ContainerInterface
     public function hasShared($alias)
     {
         return (array_key_exists($alias, $this->shared));
-    }
-
-    /**
-     * Returns true if a definition is shared.
-     *
-     * @param string $alias
-     * @return boolean
-     */
-    protected function hasSharedDefinition($alias)
-    {
-        return (array_key_exists($alias, $this->sharedDefinitions));
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -121,6 +121,22 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Asserts that asking container for an item that has a shared definition returns true.
+     */
+    public function testHasReturnsTrueForSharedDefinition()
+    {
+        $alias = 'foo';
+
+        $container = new Container;
+
+        $container->share($alias, function () {
+            return new \stdClass;
+        });
+
+        $this->assertTrue($container->has($alias));
+    }
+
+    /**
      * @param array $items
      * @return \PHPUnit_Framework_MockObject_MockObject|ImmutableContainerInterface
      */


### PR DESCRIPTION
This PR

* [x] asserts that `Container::has()` returns true if alias has a shared definition
* [x] return true if alias has a shared definition

Follows #72.

:person_with_pouting_face: Ha, I missed this one!