### PR TITLE
Fix link to delegate

### DIFF
--- a/auto-wiring.md
+++ b/auto-wiring.md
@@ -6,7 +6,7 @@ title: Auto Wiring
 
 # Auto Wiring
 
-> Note: Auto wiring is turned off by default but can be turned on by registering the `ReflectionContainer` as a container delegate. Read below and see the [documentation on delegates](/delagates/).
+> Note: Auto wiring is turned off by default but can be turned on by registering the `ReflectionContainer` as a container delegate. Read below and see the [documentation on delegates](/delegates/).
 
 Container has the power to automatically resolve your objects and all of their dependencies recursively by inspecting the type hints of your constructor arguments. Unfortunately, this method of resolution has a few small limitations but is great for smaller apps. First of all, you are limited to constructor injection and secondly, all injections must be objects.
 


### PR DESCRIPTION
Previous link to `delegate`'s page was broken within the
`auto-wiring.md` file.