### PR TITLE
Fix: Allow to fetch shared service from service provider

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -90,15 +90,15 @@ class Container implements ContainerInterface
             return $shared;
         }
 
-        if ($this->providers->provides($alias)) {
-            $this->providers->register($alias);
-            return $this->get($alias, $args);
-        }
-
         if (array_key_exists($alias, $this->definitions)) {
             return $this->inflectors->inflect(
                 $this->definitions[$alias]->build($args)
             );
+        }
+
+        if ($this->providers->provides($alias)) {
+            $this->providers->register($alias);
+            return $this->get($alias, $args);
         }
 
         if ($resolved = $this->getFromDelegate($alias, $args)) {

--- a/src/Container.php
+++ b/src/Container.php
@@ -92,6 +92,7 @@ class Container implements ContainerInterface
 
         if ($this->providers->provides($alias)) {
             $this->providers->register($alias);
+            return $this->get($alias, $args);
         }
 
         if (array_key_exists($alias, $this->definitions)) {

--- a/tests/Asset/SharedServiceProviderFake.php
+++ b/tests/Asset/SharedServiceProviderFake.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace League\Container\Test\Asset;
+
+use League\Container\ServiceProvider\AbstractServiceProvider;
+
+class SharedServiceProviderFake extends AbstractServiceProvider
+{
+    /**
+     * @var string
+     */
+    private $alias;
+
+    /**
+     * @var mixed
+     */
+    private $item;
+
+    /**
+     * @param string $alias
+     * @param mixed $item
+     */
+    public function __construct($alias, $item)
+    {
+        $this->alias = $alias;
+        $this->item = $item;
+
+        $this->provides[] = $alias;
+    }
+
+    public function register()
+    {
+        $this->getContainer()->share($this->alias, function () {
+            return $this->item;
+        });
+
+        return true;
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -4,6 +4,7 @@ namespace League\Container\Test;
 
 use League\Container\Container;
 use League\Container\ImmutableContainerInterface;
+use League\Container\Test\Asset\ServiceProviderFake;
 
 class ContainerTest extends \PHPUnit_Framework_TestCase
 {
@@ -134,6 +135,20 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         });
 
         $this->assertTrue($container->has($alias));
+    }
+
+    /**
+     * Asserts that a shared service provided by a service provider can be fetched.
+     */
+    public function testGetReturnsSharedItemFromServiceProvider()
+    {
+        $alias = 'foo';
+        $item = new \stdClass;
+
+        $container = new Container;
+        $container->addServiceProvider(new Asset\SharedServiceProviderFake($alias, $item));
+
+        $this->assertSame($item, $container->get($alias));
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] asserts that a service shared by a service provider can be fetched from the container
* [x] attempts to fetch a service for an alias after registering service provider
* [x] builds definitions first

Follows #72.

:information_desk_person: Came across this when updating a project to `league/container:^2.0.1` where I got tests, hehe.