### PR TITLE
Fix: Make sure that container delegated to will resolve from delegating container

### DIFF
--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -174,6 +174,38 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Asserts that the container to which is delegated will first resolve items from the delegating container.
+     */
+    public function testDelegatedContainerFetchesFromDelegatingContainerFirst()
+    {
+        $delegate = new Container;
+
+        $delegate->share('League\Container\Test\Asset\Foo', function () use ($delegate) {
+            $bar = $delegate->get('League\Container\Test\Asset\Bar');
+
+            return new Asset\Foo($bar);
+        });
+
+        $delegate->share('League\Container\Test\Asset\Bar', function () {
+            return new Asset\Bar();
+        });
+
+        $container = new Container;
+
+        $container->delegate($delegate);
+
+        $bar = new Asset\Bar();
+
+        $container->share('League\Container\Test\Asset\Bar', function () use ($bar) {
+            return $bar;
+        });
+
+        $foo = $container->get('League\Container\Test\Asset\Foo');
+
+        $this->assertSame($foo->bar, $bar);
+    }
+
+    /**
      * Asserts that the extend method returns a definition.
      */
     public function testExtendReturnsDefinitions()


### PR DESCRIPTION
This PR

* [x] asserts that a container which is delegated to will attempt to resolve a service from the delegating container first
* [ ] urges a container to resolve a service from the delegating container first

:information_desk_person: @philipobenito This is the gist you asked for, maybe it helps?