### PR TITLE
Taggable feature to the container

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -50,6 +50,11 @@ class Container implements ContainerInterface
     protected $delegates = [];
 
     /**
+     * @var array
+     */
+    protected $tags = [];
+
+    /**
      * Constructor.
      *
      * @param \League\Container\ServiceProvider\ServiceProviderAggregateInterface|null $providers
@@ -108,6 +113,32 @@ class Container implements ContainerInterface
         throw new NotFoundException(
             sprintf('Alias (%s) is not being managed by the container', $alias)
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tag($tag, $aliases)
+    {
+        foreach ((array) $aliases as $alias) {
+            $this->tags[$tag][] = $alias;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tagged($tag, array $args = [])
+    {
+        $result = [];
+
+        if (isset($this->tags[$tag])) {
+            foreach ($this->tags[$tag] as $alias) {
+                $result[$alias] = $this->get($alias, $args);
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -56,4 +56,21 @@ interface ContainerInterface extends ImmutableContainerInterface
      * @return mixed
      */
     public function call(callable $callable, array $args = []);
+
+    /**
+     * Group items by tag.
+     *
+     * @param string $tag
+     * @param mixed|string|array$aliases
+     * @return void
+     */
+    public function tag($tag, $aliases);
+
+    /**
+     * Get items grouped by tag.
+     *
+     * @param string $tag
+     * @return array
+     */
+    public function tagged($tag);
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -207,6 +207,39 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Assert that items in container can be grouped by tags.
+     */
+    public function testTagged()
+    {
+        $container = new Container();
+
+        $container->add('stdClass', function() {
+            return new \stdClass();
+        });
+        $container->add('container', $container);
+        $container->add('testCase', $this);
+
+        $container->tag('test-tag', ['stdClass', 'container', 'testCase']);
+
+        $tagged = $container->tagged('test-tag');
+
+        $this->assertInternalType('array', $tagged, 'Container::tagged must return an array');
+        $this->assertEquals(3, count($tagged));
+
+        $keys = array_keys($tagged);
+
+        $this->assertEquals('stdClass', $keys[0]);
+        $this->assertEquals('container', $keys[1]);
+        $this->assertEquals('testCase', $keys[2]);
+
+        $this->assertInstanceOf('stdClass', $tagged['stdClass']);
+        $this->assertInstanceOf(get_class($container), $tagged['container']);
+        $this->assertInstanceOf(get_class($this), $tagged['testCase']);
+
+
+    }
+
+    /**
      * @param array $items
      * @return \PHPUnit_Framework_MockObject_MockObject|ImmutableContainerInterface
      */


### PR DESCRIPTION
Sometimes we need to group items in a container. For example we have:

``` php

interface TaskInterface
{
 //
}

class ChoiceTask implements TaskInterface
{
  //
}

class ReadTask implements TaskInterface
{
 //
}

class OtherTask implements TaskInterface
{
 //
}

$container = new League\Container\Container;

$container->add('task.choice', 'ChoiceTask');
$container->add('task.read', 'ReadTask');

// Now we can group items
$container->tag('tasks', ['task.choice', 'task.read']); 

// ...

```

Later we can add a new one

``` php

$container->add('task.other', 'OtherTask');


```

Now we can get all tagged items

``` php

$tasks = $container->tagged('tasks');

var_dump($tasks);

/*
array(3) {
  'task.choice' =>
      class ChoiceTask#87 (0) {
  }
  'task.read' =>
      class ReadTask#88 (0) {
  }
  'task.other' =>
      class OtherTask#89 (0) {
  }
}
*/

```

Or more pretty example

``` php

// add tasks
$container->add(ChoiceTask::class);
$container->add(ReadTask::class);

// tag it
$container->tag(TaskInterface::class, [ChoiceTask::class, ReadTask::class]);

// add a new one
$container->add(OtherTask::class);

// tag it too
$container->tag(TaskInterface::class, OtherTask::class);

// get all tasks
$tasks = $container->tagged(TaskInterface::class);

var_dump($tasks);


/*
array(3) {
  'ChoiceTask' =>
       class ChoiceTask#87 (0) {
  }
  'ReadTask' =>
       class ReadTask#88 (0) {
  }
  'OtherTask' =>
       class OtherTask#89 (0) {
  }
}
*/

```
