### PR TITLE
Allow resolving of scalar values from stored RawArgument objects

### DIFF
--- a/src/Argument/ArgumentResolverTrait.php
+++ b/src/Argument/ArgumentResolverTrait.php
@@ -32,6 +32,9 @@ trait ArgumentResolverTrait
 
             if (! is_null($container) && $container->has($arg)) {
                 $arg = $container->get($arg);
+                if ($arg instanceof RawArgumentInterface) {
+                    $arg = $arg->getValue();
+                }
                 continue;
             }
         }

--- a/tests/Asset/FooWithScalarResolvedDependency.php
+++ b/tests/Asset/FooWithScalarResolvedDependency.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace League\Container\Test\Asset;
+
+class FooWithScalarResolvedDependency
+{
+    public $stringVal;
+    public $arrayVal;
+    public $integerVal;
+    public $booleanVal;
+    public $nullVal;
+
+    public function __construct($stringVal, array $arrayVal, $integerVal, $booleanVal, $nullVal)
+    {
+        $this->stringVal  = $stringVal;
+        $this->arrayVal   = $arrayVal;
+        $this->integerVal = $integerVal;
+        $this->booleanVal = $booleanVal;
+        $this->nullVal = $nullVal;
+    }
+}

--- a/tests/Definition/ClassDefinitionTest.php
+++ b/tests/Definition/ClassDefinitionTest.php
@@ -102,6 +102,46 @@ class ClassDefinitionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Asserts that a definition can build a class and inject scalar dependencies as raw argument.
+     */
+    public function testDefinitionBuildsClassAndInjectsScalarDependenciesAsRawArgumentFromContainer()
+    {
+        $container  = $this->getMock('League\Container\ImmutableContainerInterface');
+
+        $container->method('has')->will($this->returnValueMap([
+            ['string', true],
+            ['array', true],
+            ['answer', true],
+            ['false', true],
+            ['null', true],
+        ]));
+        $container->method('get')->will($this->returnValueMap([
+            ['string', new RawArgument('some_string')],
+            ['array', new RawArgument(['arr_with_key'])],
+            ['answer', new RawArgument(42)],
+            ['false', new RawArgument(false)],
+            ['null', new RawArgument(null)],
+        ]));
+
+        $definition = (new ClassDefinition('foo', 'League\Container\Test\Asset\FooWithScalarResolvedDependency'))->setContainer($container);
+
+        $definition->withArgument('string')
+                   ->withArgument('array')
+                   ->withArgument('answer')
+                   ->withArgument('false')
+                   ->withArgument('null');
+
+        $foo = $definition->build();
+
+        $this->assertInstanceOf('League\Container\Test\Asset\FooWithScalarResolvedDependency', $foo);
+        $this->assertSame('some_string', $foo->stringVal);
+        $this->assertSame(['arr_with_key'], $foo->arrayVal);
+        $this->assertSame(42, $foo->integerVal);
+        $this->assertFalse($foo->booleanVal);
+        $this->assertSame(null, $foo->nullVal);
+    }
+
+    /**
      * Asserts that a definition can build a class and inject scalar dependencies.
      */
     public function testDefinitionBuildsClassAndInjectsScalarDependencies()


### PR DESCRIPTION
In the case where a scalar parameter is set to null, Container assumes an unset value and replaces it with the $name argument. This PR enables storing RawArgument objects into the container and use the stored value upon resolving dependant's arguments.

Updated PR to match contribution guidelines.