### PR TITLE
raw argument support for "@" character

### DIFF
--- a/src/Argument/ArgumentResolverTrait.php
+++ b/src/Argument/ArgumentResolverTrait.php
@@ -35,10 +35,6 @@ trait ArgumentResolverTrait
                 continue;
             }
             
-            if (strpos($arg, '@') === 0) { // Ignore withMethodCall() "@arg" arguments
-                $arg = ltrim($arg, '@');
-            }
-            
         }
 
         return $arguments;

--- a/src/Argument/ArgumentResolverTrait.php
+++ b/src/Argument/ArgumentResolverTrait.php
@@ -34,6 +34,11 @@ trait ArgumentResolverTrait
                 $arg = $container->get($arg);
                 continue;
             }
+            
+            if (strpos($arg, '@') === 0) { // Ignore withMethodCall() "@arg" arguments
+                $arg = ltrim($arg, '@');
+            }
+            
         }
 
         return $arguments;


### PR DESCRIPTION
If i have service configuration file and i must just write raw characters ( not php ).

        foreach ($config->getMethods() as $method) {

            if (is_string($method['argument']) && strpos($method['argument'], '@') === 0) { // Ignore withMethodCall() "@arg" arguments
                $method['argument'] = ltrim($method['argument'], '@');
                $method['argument'] = new League\Container\Argument\RawArgument($method['argument']);
            }

            $logger->withMethodCall(
                $method['name'],
                $method['argument']
            );
        }

Instead of above the code, i advise raw argument support  "@",  to disable resolving of mongo object.

 $logger = $container->share('logger', 'My\Log\Logger')
            ->withArgument($container)
            ->withArgument($container->get('config'))
            ->withArgument($config->getParams())
            ->withMethodCall(
                'fileHandler',
               '@mongo'
            );