### PR TITLE
Add a 'signature' method to ServiceProviderInterface

### DIFF
--- a/src/ServiceProvider/AbstractServiceProvider.php
+++ b/src/ServiceProvider/AbstractServiceProvider.php
@@ -24,4 +24,12 @@ abstract class AbstractServiceProvider implements ServiceProviderInterface
 
         return $this->provides;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function signature()
+    {
+        return get_class($this);
+    }
 }

--- a/src/ServiceProvider/ServiceProviderAggregate.php
+++ b/src/ServiceProvider/ServiceProviderAggregate.php
@@ -72,12 +72,12 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
         $provider = $this->providers[$service];
 
         // ensure that the provider hasn't already been invoked by any other service request
-        if (in_array(get_class($provider), $this->registered)) {
+        if (in_array($provider->signature(), $this->registered)) {
             return;
         }
 
         $provider->register();
 
-        $this->registered[] = get_class($provider);
+        $this->registered[] = $provider->signature();
     }
 }

--- a/src/ServiceProvider/ServiceProviderInterface.php
+++ b/src/ServiceProvider/ServiceProviderInterface.php
@@ -23,4 +23,13 @@ interface ServiceProviderInterface extends ContainerAwareInterface
      * @return void
      */
     public function register();
+
+    /**
+     * The signature of the service provider uniquely identifies it, so
+     * that we can quickly determine if it has already been registered.
+     * Defaults to get_class($provider).
+     *
+     * @return string
+     */
+    public function signature();
 }

--- a/tests/Asset/SharedServiceProviderFake.php
+++ b/tests/Asset/SharedServiceProviderFake.php
@@ -17,15 +17,21 @@ class SharedServiceProviderFake extends AbstractServiceProvider
     private $item;
 
     /**
+     * @var string
+     */
+    private $signature;
+
+    /**
      * @param string $alias
      * @param mixed $item
      */
-    public function __construct($alias, $item)
+    public function __construct($alias, $item, $signature = false)
     {
         $this->alias = $alias;
         $this->item = $item;
 
         $this->provides[] = $alias;
+        $this->signature = $signature ?: get_class($this);
     }
 
     public function register()
@@ -35,5 +41,10 @@ class SharedServiceProviderFake extends AbstractServiceProvider
         });
 
         return true;
+    }
+
+    public function signature()
+    {
+        return $this->signature;
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -153,6 +153,51 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Asserts that the same service provider class cannot be used to
+     * register two different sets of services.
+     */
+    public function testSameServiceProviderClassCannotBeUsedTwice()
+    {
+        $alias = 'foo';
+        $item = new \stdClass;
+
+        $alias2 = 'bar';
+        $item2 = new \stdClass;
+
+        $container = new Container;
+        $container->addServiceProvider(new Asset\SharedServiceProviderFake($alias, $item));
+        $container->addServiceProvider(new Asset\SharedServiceProviderFake($alias2, $item2));
+
+        $this->assertSame($item, $container->get($alias));
+
+        $this->setExpectedException('League\Container\Exception\NotFoundException');
+
+        $container->get($alias2);
+    }
+
+    /**
+     * Asserts that the same service provider class cannot be used to
+     * register two different sets of services.
+     */
+    public function testSameServiceProviderClassCanBeUsedTwiceWithDifferentSignatures()
+    {
+        $alias = 'foo';
+        $item = new \stdClass;
+        $signature1 = 'foo';
+
+        $alias2 = 'bar';
+        $item2 = new \stdClass;
+        $signature2 = 'bar';
+
+        $container = new Container;
+        $container->addServiceProvider(new Asset\SharedServiceProviderFake($alias, $item, $signature1));
+        $container->addServiceProvider(new Asset\SharedServiceProviderFake($alias2, $item2, $signature2));
+
+        $this->assertSame($item, $container->get($alias));
+        $this->assertSame($item2, $container->get($alias2));
+    }
+
+    /**
      * Asserts that the container to which is delegated can resolve items from the delegating container.
      */
     public function testDelegateSharesContainer()


### PR DESCRIPTION
The existing ServiceProviderAggregate invariantly uses `get_class` to keep track of each provider to quickly and efficiently check to see if it has already been registered at some point in the past. This implementation prevents the use of the same Provider class to register services for multiple service providers.

For example, in instances where an application has a number of providers, all of which register services in a similar way, then a single simple service provider, such as [SimpleServiceProvider](https://github.com/Codegyre/Robo/blob/task-assembly/src/Container/SimpleServiceProvider.php) could potentially be used to handle all of them.  ([Example usage](https://github.com/Codegyre/Robo/blob/task-assembly/src/Task/File/loadTasks.php#L14)).

This technique works fine for the first module, but the second use of the same provider is not registered due to the `get_class` check in  ServiceProviderAggregate.

This PR adds a `signature` method to the ServiceProviderInterface, so that providers such as the SimpleServiceProvider may provide some different signature than its class name. The AbstractServiceProvider provides a default implementation of `signature` that simply returns `get_class`, so existing providers that extend AbstractServiceProvider will continue to function in the same way they always have.

The one downside of this implementation is that any provider that implements ServiceProviderInterface without extending AbstractServiceProvider will break, and will need to add a signature method in order to work again. This adjustment is trivial, but does break backwards compatibility.

If the concept of this PR looks acceptable, but strict backwards compatibility is desired, then I could add another ServiceProviderSignatureInterface, and test for it in ServiceProviderAggregate with a fallback to `get_class` for providers that do not implement the new interface. Such an implementation would be slightly more awkward than what is presented here, but would maintain strict backwards compatibility.

