### PR TITLE
Fix: Rename parameter

### DIFF
--- a/src/ServiceProvider/ServiceProviderAggregateInterface.php
+++ b/src/ServiceProvider/ServiceProviderAggregateInterface.php
@@ -25,8 +25,8 @@ interface ServiceProviderAggregateInterface extends ContainerAwareInterface
     /**
      * Invokes the register method of a provider that provides a specific service.
      *
-     * @param  string $provider
+     * @param  string $service
      * @return void
      */
-    public function register($provider);
+    public function register($service);
 }


### PR DESCRIPTION
This PR

* [x] renames a parameter

Somewhat, but not really related to #96.

:information_desk_person: The parameter is called `$service` in the implementation, and as it is a string, it should probably the service identifier, rather than the actual provider.
