### PR TITLE
Fixes ReflectionContainer::call for invokable objects.

### DIFF
--- a/src/ReflectionContainer.php
+++ b/src/ReflectionContainer.php
@@ -71,6 +71,12 @@ class ReflectionContainer implements
             return $reflection->invokeArgs($callable[0], $this->reflectArguments($reflection, $args));
         }
 
+        if (is_object($callable)) {
+            $reflection = new ReflectionMethod($callable, '__invoke');
+
+            return $reflection->invokeArgs($callable, $this->reflectArguments($reflection, $args));
+        }
+
         $reflection = new ReflectionFunction($callable);
 
         return $reflection->invokeArgs($this->reflectArguments($reflection, $args));

--- a/tests/ReflectionContainerTest.php
+++ b/tests/ReflectionContainerTest.php
@@ -166,6 +166,16 @@ class ReflectionContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests the support for __invokable/callable classes for the ReflectionContainer::call method.
+     */
+    public function testInvokableClass()
+    {
+        $container = new ReflectionContainer;
+
+        $container->call(new Asset\FooWithNamedConstructor, [new Asset\Bar()]);
+    }
+
+    /**
      * @param array $items
      * @return \PHPUnit_Framework_MockObject_MockObject|ImmutableContainerInterface
      */


### PR DESCRIPTION
This commit fixes a compatibility issue between leauge/container and
league/route. With this fix it is possible to use "Action Controller" or
"Magic __invoke" able Controller with the ParamStrategy.

In fact it simply fixes callable classes in conjunction with the
ReflectionContainer. It should be fully backwards compatible as the
function itself relies on the 'callable' typehint for its first
parameter.