### PR TITLE
allow to override a concrete value with callable definition

### DIFF
--- a/src/Definition/ConcreteDefinition.php
+++ b/src/Definition/ConcreteDefinition.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace League\Container\Definition;
+
+class ConcreteDefinition implements DefinitionInterface
+{
+    /**
+     * @var string
+     */
+    private $alias;
+
+    /**
+     * @var mixed
+     */
+    private $concrete;
+
+    /**
+     * Constructor.
+     *
+     * @param string $alias
+     * @param mixed  $concrete
+     */
+    public function __construct($alias, & $concrete)
+    {
+        $this->alias     = $alias;
+        $this->concrete  = & $concrete;
+    }
+
+    /**
+     * Handle instantiation and manipulation of value and return.
+     *
+     * @param  array $args
+     * @return mixed
+     */
+    public function & build(array $args = [])
+    {
+        return $this->concrete;
+    }
+
+    /**
+     * Add an argument to be injected.
+     *
+     * @param  mixed $arg
+     * @return $this
+     */
+    public function withArgument($arg)
+    {
+        return $this;
+    }
+
+    /**
+     * Add multiple arguments to be injected.
+     *
+     * @param  array $args
+     * @return $this
+     */
+    public function withArguments(array $args)
+    {
+        return $this;
+    }
+}

--- a/src/Definition/DefinitionFactory.php
+++ b/src/Definition/DefinitionFactory.php
@@ -23,6 +23,6 @@ class DefinitionFactory implements DefinitionFactoryInterface
 
         // if the item is not defineable we just return the value to be stored
         // in the container as an arbitrary value/instance
-        return $concrete;
+        return new ConcreteDefinition($alias, $concrete);
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -3,6 +3,7 @@
 namespace League\Container\Test;
 
 use League\Container\Container;
+use League\Container\Definition\DefinitionInterface;
 use League\Container\ImmutableContainerInterface;
 use League\Container\ReflectionContainer;
 
@@ -294,5 +295,15 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $container->add('test', 'bad');
         $container->add('test', function() { return 'good'; });
         $this->assertEquals('good', $container->get('test'));
+    }
+
+    /**
+     * asserts that add returns an instance of DefinitionInterface.
+     */
+    public function testConcreteValueReturnsDefinitionInterfaceObject()
+    {
+        $container = new Container;
+
+        $this->assertTrue($container->add('test', 'good') instanceof DefinitionInterface);
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -279,4 +279,20 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         return $container;
     }
+
+    /**
+     * asserts that definitions are overridden by subsequent add method.
+     */
+    public function testOverrideAlias()
+    {
+        $container = new Container;
+
+        $container->add('test', function() { return 'bad'; });
+        $container->add('test', function() { return 'good'; });
+        $this->assertEquals('good', $container->get('test'));
+
+        $container->add('test', 'bad');
+        $container->add('test', function() { return 'good'; });
+        $this->assertEquals('good', $container->get('test'));
+    }
 }

--- a/tests/Definition/DefinitionFactoryTest.php
+++ b/tests/Definition/DefinitionFactoryTest.php
@@ -59,15 +59,15 @@ class DefinitionFactoryTest extends \PHPUnit_Framework_TestCase
 
         // neither
         $str = 'some_string';
-        $this->assertSame($str, $factory->getDefinition('foo', $str, $container));
+        $this->assertSame($str, $factory->getDefinition('foo', $str, $container)->build());
 
         $arr = ['some_array'];
-        $this->assertSame($arr, $factory->getDefinition('foo', $arr, $container));
+        $this->assertSame($arr, $factory->getDefinition('foo', $arr, $container)->build());
 
         $i = 42;
-        $this->assertSame($i, $factory->getDefinition('foo', $i, $container));
+        $this->assertSame($i, $factory->getDefinition('foo', $i, $container)->build());
 
         $bool = false;
-        $this->assertSame($bool, $factory->getDefinition('foo', $bool, $container));
+        $this->assertSame($bool, $factory->getDefinition('foo', $bool, $container)->build());
     }
 }


### PR DESCRIPTION
This pull-request addresses 2 issues. 
## cannot override a concrete value

While this code overrides the `test` value, 

``` php
$container->add('test', function() { return 'bad'; });
$container->add('test', function() { return 'good'; });
$this->assertEquals('good', $container->get('test'));
```

but this one fails to override a concrete value. 

``` php
$container->add('test', 'bad');
$container->add('test', function() { return 'good'; });
$this->assertEquals('good', $container->get('test')); // fail!
```

I found a concrete value is considered as shared, and callable and class definitions cannot be resolved because a shared value already exists. 
## method `add` returns null for a concrete value

According to the API (doc block) the `add` method returns `DefinitionInterface` but returns null if a concrete value is set. 

``` php
$this->assertTrue($container->add('test', 'good') instanceof DefinitionInterface);
```
## BC break?

This PR fixes the above 2 issues, but changes what `add` and `share` method may return, which can be considered as a BC break. 
