### PR TITLE
Single instance container

### DIFF
--- a/src/SingleInstanceContainer.php
+++ b/src/SingleInstanceContainer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace League\Container;
+
+use Interop\Container\ContainerInterface as InteropContainerInterface;
+
+/**
+ * Wraps a container intercepting requests for dependencies and caching the return.
+ *
+ * This ensures that a single instance of any service ID is only ever returned. This
+ * be used with a reflection container to provide zero-configuration, single instance
+ * DI.
+ */
+class SingleInstanceContainer implements InteropContainerInterface
+{
+    /**
+     * @var InteropContainerInterface
+     */
+    private $wrapped;
+    
+    /**
+     * @var mixed[]
+     */
+    private $instances = [];
+    
+    
+    /**
+     * @param InteropContainerInterface $container
+     */
+    public function __construct(InteropContainerInterface $container)
+    {
+        $this->wrapped = $container;
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function get($id)
+    {
+        if (!isset($this->instances[$id])) {
+            $this->instances[$id] = $this->wrapped->get($id);
+        }
+        
+        return $this->instances[$id];
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function has($id)
+    {
+        return $this->wrapped->has($id);
+    }
+}

--- a/tests/SingleInstanceContainerTest.php
+++ b/tests/SingleInstanceContainerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace League\Container\Test;
+
+use Interop\Container\ContainerInterface;
+use League\Container\Exception\NotFoundException;
+use League\Container\Test\Asset\Foo;
+
+class SingleInstanceContainerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $alias
+     * @param bool   $expected
+     *
+     * @dataProvider provideHasExpectations
+     */
+    public function testHas($alias, $expected)
+    {
+        $wrapped = $this->getMockContainer([
+            'foo' => new Foo(),
+        ]);
+        
+        $container = new \League\Container\SingleInstanceContainer($wrapped);
+        
+        $this->assertSame($expected, $container->has($alias));
+    }
+    
+    public function provideHasExpectations()
+    {
+        return [
+            ['foo', true],
+            ['bar', false],
+        ];
+    }
+    
+    public function testGet()
+    {
+        $object  = new Foo();
+        
+        $wrapped = $this->getMockContainer([
+            'foo' => $object
+        ]);
+        
+        $container = new \League\Container\SingleInstanceContainer($wrapped);
+    
+        $this->assertSame($object, $container->get('foo'));
+    }
+    
+    public function testGetThrowsWhenWrappedContainerNotFound()
+    {
+        $wrapped = $this->getMockContainer();
+    
+        $container = new \League\Container\SingleInstanceContainer($wrapped);
+        
+        $this->setExpectedException('\League\Container\Exception\NotFoundException');
+        
+        $container->get('foo');
+    }
+    
+    public function testGetReturnsSameInstance()
+    {
+        $wrapped = $this->getMockContainer([
+            'foo' => function () {
+                return new Foo();
+            }
+        ]);
+        
+        $this->assertNotSame($wrapped->get('foo'), $wrapped->get('foo'));
+        
+        $container = new \League\Container\SingleInstanceContainer($wrapped);
+    
+        $this->assertSame($container->get('foo'), $container->get('foo'));
+    }
+    
+    /**
+     * @param array $mapping Id => service key-value mapping
+     *
+     * @return ContainerInterface
+     */
+    private function getMockContainer(array $mapping = [])
+    {
+        $container = $this->getMock('\Interop\Container\ContainerInterface');
+        
+        $container->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(
+                function ($alias) use ($mapping) {
+                    if (!isset($mapping[$alias])) {
+                        throw new NotFoundException();
+                    }
+                    
+                    if (is_callable($mapping[$alias])) {
+                        return $mapping[$alias]();
+                    }
+                    
+                    return $mapping[$alias];
+                }
+            );
+        
+        $container->expects($this->any())
+            ->method('has')
+            ->willReturnCallback(
+                function ($alias) use ($mapping) {
+                    return isset($mapping[$alias]);
+                }
+            );
+        
+        return $container;
+    }
+}


### PR DESCRIPTION
Hi,

Not sure if I've missed an existing solution for this problem, but I wanted to ensure that autowiring spat out the same instance only once for each type. I've implemented a thin container to solve a problem.
```php
<?php

require 'vendor/autoload.php';

class Foo { }

class Bar
{
    public $foo;
    
    public function __construct(Foo $foo)
    {
        $this->foo = $foo;
    }
}

// Using a reflection container alone.
$container = new \League\Container\Container();
$container->delegate(new League\Container\ReflectionContainer());

$foo = $container->get(Foo::class);
$bar = $container->get(Bar::class);

var_dump($foo === $bar->foo);       // false

// Using a reflection container mixed with a single instance container.
$reflectionContainer = new League\Container\ReflectionContainer();
$singleContainer     = new \League\Container\SingleInstanceContainer($reflectionContainer);
// Configure the reflection container to use the single-instance
// container when resolving arguments.
$reflectionContainer->setContainer($singleContainer);

$container = new \League\Container\Container();
$container->delegate($singleContainer);

$foo = $container->get(Foo::class);
$bar = $container->get(Bar::class);

var_dump($foo === $bar->foo);       // true
```

Is there an existing solution that is more appropriate? If not, would this be helpful at all?

Thanks,
Andy