### PR TITLE
Fix: Docblock

### DIFF
--- a/src/Argument/ArgumentResolverTrait.php
+++ b/src/Argument/ArgumentResolverTrait.php
@@ -76,7 +76,7 @@ trait ArgumentResolverTrait
     }
 
     /**
-     * @return ContainerInterface
+     * @return \League\Container\ContainerInterface
      */
     abstract public function getContainer();
 }


### PR DESCRIPTION
This PR

* [x] fixes a `@return` annotation in a docblock as otherwise, `ContainerInterface` would be an undefined class