### PR TITLE
Fix: Limit range of accepted PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": "^5.4.0 || ^7.0",
         "container-interop/container-interop": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
This PR

* [x] limits the range of accepted PHP versions

💁 Because we can't tell yet whether `league/container` will be compatible with PHP 9000.