### PR TITLE
Fix: Handle boolean values set on containers

### DIFF
--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -23,8 +23,10 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($container->get('test', ['hello']), 'hello');
         $this->assertEquals($container->get('test', ['world']), 'world');
+        $this->assertEquals($container->get('test', [true]), true);
+        $this->assertEquals($container->get('test', [false]), false);
     }
-
+    
     /**
      * Asserts that the container sets and gets an instance as shared.
      */


### PR DESCRIPTION
This change fixes the behavior of the Container::getFromThisContainer()
and Container::getFromDelegate() methods. Both of these methods return
either a value resolved from the container/delegate/provider or false.
While registering services that return a boolean false is allowed,
retrieving them caused a NotFoundException to bubble as the calling
method, Container::get() cannot differentiate from false literals
returned as a value from the container and false values returned by
the underlying methods failing to resolve an alias.

This change modifies the above methods to always return the resolved
value OR throw a NotFoundException which corrects the problematic
behavior of returning a value (false) as an indicator of an exception state
(method was asked for a thing and couldn't provide it).

This would fix issue #103 
