### PR TITLE
Provider lazy loader at service level

### DIFF
--- a/docs/3.x/service-providers.md
+++ b/docs/3.x/service-providers.md
@@ -40,16 +40,27 @@ class SomeServiceProvider extends AbstractServiceProvider
      * that you need to, but remember, every alias registered
      * within this method must be declared in the `$provides` array.
      */
-    public function register()
+    public function register($alias)
     {
-        $this->getContainer()->add('key', 'value');
+        switch ($alias) {
+            case 'key': 
+                $this->getContainer()->add('key', 'value');
+                break;
+            case 'Some\Controller':
+                $this->getContainer()->add('Some\Controller')
+                     ->withArgument('Some\Request')
+                     ->withArgument('Some\Model');
 
-        $this->getContainer()->add('Some\Controller')
-             ->withArgument('Some\Request')
-             ->withArgument('Some\Model');
+                break;
+            case 'Some\Request':
+                $this->getContainer()->add('Some\Request');
+                break;
+            case 'Some\Model':
+                $this->getContainer()->add('Some\Model');
+                break;
+        }
 
-        $this->getContainer()->add('Some\Request');
-        $this->getContainer()->add('Some\Model');
+
     }
 }
 ~~~
@@ -110,7 +121,7 @@ class SomeServiceProvider extends AbstractServiceProvider implements BootableSer
     /**
      * {@inheritdoc}
      */
-    public function register()
+    public function register($alias)
     {
         // ...
     }

--- a/src/ServiceProvider/ServiceProviderAggregate.php
+++ b/src/ServiceProvider/ServiceProviderAggregate.php
@@ -70,19 +70,15 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
         }
 
         $provider  = $this->providers[$service];
-        $signature = get_class($provider);
 
-        if ($provider instanceof SignatureServiceProviderInterface) {
-            $signature = $provider->getSignature();
-        }
-
-        // ensure that the provider hasn't already been invoked by any other service request
-        if (in_array($signature, $this->registered)) {
+        // ensure that the service hasn't already been invoked by any other service request
+        if (in_array($service, $this->registered)) {
             return;
         }
 
-        $provider->register();
+        // we pass the wanted service to the provider
+        $provider->register($service);
 
-        $this->registered[] = $signature;
+        $this->registered[] = $service;
     }
 }

--- a/src/ServiceProvider/ServiceProviderAggregate.php
+++ b/src/ServiceProvider/ServiceProviderAggregate.php
@@ -18,6 +18,7 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
      * @var array
      */
     protected $registered = [];
+    protected $registered_services = [];
 
     /**
      * {@inheritdoc}
@@ -68,17 +69,24 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
                 sprintf('(%s) is not provided by a service provider', $service)
             );
         }
-
+        
         $provider  = $this->providers[$service];
 
-        // ensure that the service hasn't already been invoked by any other service request
-        if (in_array($service, $this->registered)) {
+        $signature = get_class($provider);
+        if ($provider instanceof SignatureServiceProviderInterface) {
+            $signature = $provider->getSignature();
+        }
+
+        // ensure that the provider hasn't already been invoked by any other service request
+        if (in_array($signature, $this->registered) 
+            && isset($this->registered_services[$signature]) 
+            && in_array($service, $this->registered_services[$signature])) {
             return;
         }
 
-        // we pass the wanted service to the provider
         $provider->register($service);
+        $this->registered[] = $signature;
+        $this->registered_service[$signature] = $service;
 
-        $this->registered[] = $service;
     }
 }

--- a/src/ServiceProvider/ServiceProviderInterface.php
+++ b/src/ServiceProvider/ServiceProviderInterface.php
@@ -20,7 +20,8 @@ interface ServiceProviderInterface extends ContainerAwareInterface
      * protected $this->container property or the `getContainer` method
      * from the ContainerAwareTrait.
      *
+     * @param  string $alias The service to be registered
      * @return void
      */
-    public function register();
+    public function register($alias);
 }

--- a/tests/Asset/ServiceProviderFake.php
+++ b/tests/Asset/ServiceProviderFake.php
@@ -17,11 +17,16 @@ class ServiceProviderFake extends AbstractServiceProvider implements BootableSer
         return true;
     }
 
-    public function register()
+    public function register($alias)
     {
-        $this->getContainer()->add('SomeService', function ($arg) {
-            return $arg;
-        });
+        switch ($alias) {
+            case 'SomeService':
+                $this->getContainer()->add('SomeService', function ($arg) {
+                    return $arg;
+                });
+
+                break;
+        }
 
         return true;
     }

--- a/tests/Asset/SharedServiceProviderFake.php
+++ b/tests/Asset/SharedServiceProviderFake.php
@@ -28,11 +28,13 @@ class SharedServiceProviderFake extends AbstractServiceProvider
         $this->provides[] = $alias;
     }
 
-    public function register()
+    public function register($alias)
     {
-        $this->getContainer()->share($this->alias, function () {
-            return $this->item;
-        });
+        if($alias == $this->alias) {
+            $this->getContainer()->share($this->alias, function () {
+                return $this->item;
+            });
+        }
 
         return true;
     }

--- a/tests/Asset/SharedServiceProviderWithSignatureFake.php
+++ b/tests/Asset/SharedServiceProviderWithSignatureFake.php
@@ -32,11 +32,13 @@ class SharedServiceProviderWithSignatureFake extends AbstractSignatureServicePro
         $this->withSignature($signature);
     }
 
-    public function register()
+    public function register($alias)
     {
-        $this->getContainer()->share($this->alias, function () {
-            return $this->item;
-        });
+        if ($alias == $this->alias) {
+            $this->getContainer()->share($this->alias, function () {
+                return $this->item;
+            });
+        }
 
         return true;
     }

--- a/tests/ServiceProvider/ServiceProviderAggregateTest.php
+++ b/tests/ServiceProvider/ServiceProviderAggregateTest.php
@@ -48,14 +48,14 @@ class ServiceProviderAggregateTest extends \PHPUnit_Framework_TestCase
         $aggregate->register('SomeService');
     }
 
-    public function testAggregateInvokesCorrectRegisterMethodOnlyOnce()
+    public function testAggregateInvokesCorrectRegisterMethodOnePerService()
     {
         $container = $this->getMock('League\Container\ContainerInterface');
         $aggregate = (new ServiceProviderAggregate)->setContainer($container);
         $provider  = $this->getMock('League\Container\Test\Asset\ServiceProviderFake');
 
         $provider->expects($this->once())->method('boot');
-        $provider->expects($this->once())->method('register');
+        $provider->expects($this->exactly(2))->method('register');
         $provider->expects($this->once())->method('provides')->will($this->returnValue(['SomeService', 'AnotherService']));
 
 


### PR DESCRIPTION
Hi,

We have been using this container for a while, and we had a lot of services defined in our provider. The fact the the register always load all the services creates a lot of overhead on our case. 

I think a better approach will be to register only the wanted services, and in this case the code will be lazy at service level, not at provider level as it is now.

The only problem is that this change has a incompatible change backwards regarding the interface. I have added a new $alias argument to register function to be able on the provider to only register the wanted service.

The provider can be something like:
`` 
> class CommonService extends AbstractServiceProvider
>     {
>     protected $provides = [
>         'service1',
>         'service2',
>         'service3',
>     ];
> 
>     public function register($alias = null)
>     {
>         switch ($alias) {
>             case 'service1':
>                 //register service1 here
>                 break;
>             case 'service2':
>                 //register service2 here
> [...]
>         }
>     }
        
`` 

There is one test that it is failing to assert but I don't understand exactly what it should done: 
testSameServiceProviderClassCannotBeUsedTwice

Regards, 