### PR TITLE
Fix for issue #149

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -73,10 +73,10 @@ class Container implements ContainerInterface
      *
      * @return \League\Container\Definition\DefinitionInterface
      */
-    public function add(string $id, $concrete = null, bool $shared = false) : DefinitionInterface
+    public function add(string $id, $concrete = null, bool $shared = null) : DefinitionInterface
     {
         $concrete = $concrete ?? $id;
-        $shared   = ($this->defaultToShared === true || $shared === true);
+        $shared = ($shared === null) ? $this->defaultToShared : $shared;
 
         return $this->definitions->add($id, $concrete, $shared);
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -76,7 +76,7 @@ class Container implements ContainerInterface
     public function add(string $id, $concrete = null, bool $shared = null) : DefinitionInterface
     {
         $concrete = $concrete ?? $id;
-        $shared = ($shared === null) ? $this->defaultToShared : $shared;
+        $shared = $shared ?? $this->defaultToShared;
 
         return $this->definitions->add($id, $concrete, $shared);
     }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -53,7 +53,7 @@ class ContainerTest extends TestCase
     {
         $container = (new Container)->defaultToShared();
 
-        $container->share(Foo::class);
+        $container->add(Foo::class);
 
         $this->assertTrue($container->has(Foo::class));
 
@@ -63,6 +63,25 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(Foo::class, $fooOne);
         $this->assertInstanceOf(Foo::class, $fooTwo);
         $this->assertSame($fooOne, $fooTwo);
+    }
+
+    /**
+     * Asserts that the container can add and get a service defined as shared.
+     */
+    public function testContainerAddsNonSharedWithSharedByDefault()
+    {
+        $container = (new Container)->defaultToShared();
+
+        $container->add(Foo::class, null, false);
+
+        $this->assertTrue($container->has(Foo::class));
+
+        $fooOne = $container->get(Foo::class);
+        $fooTwo = $container->get(Foo::class);
+
+        $this->assertInstanceOf(Foo::class, $fooOne);
+        $this->assertInstanceOf(Foo::class, $fooTwo);
+        $this->assertNotSame($fooOne, $fooTwo);
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -66,7 +66,7 @@ class ContainerTest extends TestCase
     }
 
     /**
-     * Asserts that the container can add and get a service defined as shared.
+     * Asserts that the container can add and get a service defined as non-shared with defaultToShared enabled.
      */
     public function testContainerAddsNonSharedWithSharedByDefault()
     {


### PR DESCRIPTION
This fixes the issue where it was not able to register a non-shared definition when `defaultToShared` was enabled.