### PR TITLE
Add getConcrete and setConcrete on the definition

### DIFF
--- a/src/Definition/Definition.php
+++ b/src/Definition/Definition.php
@@ -119,6 +119,24 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     /**
      * {@inheritdoc}
      */
+    public function getConcrete()
+    {
+        return $this->concrete;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConcrete($concrete): DefinitionInterface
+    {
+        $this->concrete = $concrete;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function addArgument($arg) : DefinitionInterface
     {
         $this->arguments[] = $arg;

--- a/src/Definition/DefinitionInterface.php
+++ b/src/Definition/DefinitionInterface.php
@@ -55,6 +55,22 @@ interface DefinitionInterface extends ContainerAwareInterface
     public function isShared() : bool;
 
     /**
+     * Get the concrete of the definition.
+     *
+     * @return mixed
+     */
+    public function getConcrete();
+
+    /**
+     * Set the concrete of the definition.
+     *
+     * @param mixed $concrete
+     *
+     * @return DefinitionInterface
+     */
+    public function setConcrete($concrete): DefinitionInterface;
+
+    /**
      * Add an argument to be injected.
      *
      * @param mixed $arg

--- a/tests/Definition/DefinitionTest.php
+++ b/tests/Definition/DefinitionTest.php
@@ -167,4 +167,28 @@ class DefinitionTest extends TestCase
         $this->assertTrue($definition->hasTag('tag2'));
         $this->assertFalse($definition->hasTag('tag3'));
     }
+
+    /**
+     * Assert that the definition returns the concrete.
+     */
+    public function testDefinitionCanGetConcrete()
+    {
+        $concrete = new ClassName(Foo::class);
+        $definition = new Definition('callable', $concrete);
+
+        $this->assertSame($concrete, $definition->getConcrete());
+    }
+
+    /**
+     * Assert that the definition set the concrete.
+     */
+    public function testDefinitionCanSetConcrete()
+    {
+        $definition = new Definition('callable', null);
+
+        $concrete = new ClassName(Foo::class);
+        $definition->setConcrete($concrete);
+
+        $this->assertSame($concrete, $definition->getConcrete());
+    }
 }


### PR DESCRIPTION
Added a `getConcrete` and `setConcrete` method to the definition.

This fixes #151.