### PR TITLE
Fix issue where providers may be aggregated multiple times

### DIFF
--- a/src/ServiceProvider/ServiceProviderAggregate.php
+++ b/src/ServiceProvider/ServiceProviderAggregate.php
@@ -31,6 +31,10 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
             $provider = new $provider;
         }
 
+        if (in_array($provider, $this->providers)) {
+            return $this;
+        }
+
         if ($provider instanceof ContainerAwareInterface) {
             $provider->setContainer($this->getContainer());
         }

--- a/tests/ServiceProvider/ServiceProviderAggregateTest.php
+++ b/tests/ServiceProvider/ServiceProviderAggregateTest.php
@@ -24,10 +24,13 @@ class ServiceProviderAggregateTest extends TestCase
                 'AnotherService'
             ];
 
+            public $booted     = 0;
             public $registered = 0;
 
             public function boot()
             {
+                $this->booted++;
+
                 return true;
             }
 
@@ -101,5 +104,28 @@ class ServiceProviderAggregateTest extends TestCase
         $aggregate->register('AnotherService');
 
         $this->assertSame(1, $provider->registered);
+    }
+
+
+    /**
+     * Asserts that adding a provider that has already been aggregated
+     * will skip subsequent attempts to add the provider
+     */
+    public function testAggregateSkipsExistingProviders()
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = (new ServiceProviderAggregate)->setContainer($container);
+        $provider  = $this->getServiceProvider();
+
+        $aggregate->add($provider);
+        $aggregate->add($provider);
+
+        // assert after adding provider multiple times, that it
+        // was only aggregated and booted once
+        $this->assertSame(
+            [$provider],
+            iterator_to_array($aggregate->getIterator())
+        );
+        $this->assertSame(1, $provider->booted);
     }
 }


### PR DESCRIPTION
When a ServiceProvider is added multiple times (either directly
or by other ServiceProviders), it should only be aggregated once.

This prevents iterating over the same ServiceProvider multiple times
when a service is provided by a provider farther down in the providers
stack, as well as executing the `boot()` method multiple times on any
BootableServiceProviders.

Fixes https://github.com/thephpleague/container/issues/157