### PR TITLE
Fix stack overflow error incase a service provider lies about providing a specific service

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -3,7 +3,7 @@
 namespace League\Container;
 
 use League\Container\Definition\{DefinitionAggregate, DefinitionInterface, DefinitionAggregateInterface};
-use League\Container\Exception\NotFoundException;
+use League\Container\Exception\{NotFoundException, ContainerException};
 use League\Container\Inflector\{InflectorAggregate, InflectorInterface, InflectorAggregateInterface};
 use League\Container\ServiceProvider\{ServiceProviderAggregate, ServiceProviderAggregateInterface};
 use Psr\Container\ContainerInterface;
@@ -166,6 +166,11 @@ class Container implements ContainerInterface
 
         if ($this->providers->provides($id)) {
             $this->providers->register($id);
+            
+            if(!$this->definitions->has($id) && !$this->definitions->hasTag($id)) {
+                throw new ContainerException(sprintf('Service provider lied about providing (%s) service', $id));    
+            }
+            
             return $this->get($id, $new);
         }
 


### PR DESCRIPTION
in case a service provider returns true when `provides(string $service): bool` is called, but doesn't actually provide it, a stack overflow will occur ( `->get()` calls `->get()` over and over again ) resulting in a fatal error. throwing an exception in this case is better.

i have faced this issue while working in [`nuxed/container`](https://github.com/nuxed/framework/tree/master/src/Nuxed/Container) ( since the container package is a re-implementation of the league container in hack lang ) ( see : https://github.com/nuxed/framework/commit/4f693abfb1d55aeef83c5ca2423262d5687d6d04 )