### PR TITLE
Add `/docs` to export ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 /phpunit.xml.dist   export-ignore
 /.scrutinizer.yml   export-ignore
 /tests              export-ignore
+/docs               export-ignore


### PR DESCRIPTION
This is to reduce package size when installing with `--prefer-dist` flag