### PR TITLE
Add phpstan, bump minimum PHP version to 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 7.0
     - 7.1
     - 7.2
     - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 
 script:
     - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+    - vendor/bin/phpstan analyse src
 
 after_success:
     - wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/thephpl
 ## Running Tests
 
 ``` bash
-$ phpunit
+$ composer test
 ```
 
 **Happy coding**!

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Contribute to this documentation in the [gh-pages branch](https://github.com/the
 ## Testing
 
 ``` bash
-$ vendor/bin/phpunit
+$ composer test
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ $ composer require league/container
 
 The following versions of PHP are supported by this version.
 
-* PHP 7.0
 * PHP 7.1
 * PHP 7.2
+* PHP 7.3
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,10 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "php": "^7.1",
         "phpunit/phpunit" : "^6.0",
         "squizlabs/php_codesniffer": "^3.3",
         "phpstan/phpstan": "^0.11.8"

--- a/composer.json
+++ b/composer.json
@@ -51,5 +51,11 @@
             "dev-2.x": "2.x-dev",
             "dev-1.x": "1.x-dev"
         }
+    },
+    "scripts": {
+        "test": [
+            "phpunit",
+            "phpstan analyse src/"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,10 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
+        "php": "^7.1",
         "phpunit/phpunit" : "^6.0",
-        "squizlabs/php_codesniffer": "^3.3"
+        "squizlabs/php_codesniffer": "^3.3",
+        "phpstan/phpstan": "^0.11.8"
     },
     "provide": {
         "psr/container-implementation": "^1.0"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,2 @@
+includes:
+  - vendor/phpstan/phpstan/conf/config.level7.neon

--- a/src/Definition/Definition.php
+++ b/src/Definition/Definition.php
@@ -259,7 +259,10 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     {
         foreach ($this->methods as $method) {
             $args = $this->resolveArguments($method['arguments']);
-            call_user_func_array([$instance, $method['method']], $args);
+
+            /** @var callable $callable */
+            $callable = [$instance, $method['method']];
+            call_user_func_array($callable, $args);
         }
 
         return $instance;

--- a/src/Inflector/Inflector.php
+++ b/src/Inflector/Inflector.php
@@ -103,14 +103,17 @@ class Inflector implements ArgumentResolverInterface, InflectorInterface
         $properties = $this->resolveArguments(array_values($this->properties));
         $properties = array_combine(array_keys($this->properties), $properties);
 
-        foreach ($properties as $property => $value) {
+        // array_combine() can technically return false
+        foreach ($properties ?: [] as $property => $value) {
             $object->{$property} = $value;
         }
 
         foreach ($this->methods as $method => $args) {
             $args = $this->resolveArguments($args);
 
-            call_user_func_array([$object, $method], $args);
+            /** @var callable $callable */
+            $callable = [$object, $method];
+            call_user_func_array($callable, $args);
         }
 
         if ($this->callback !== null) {

--- a/src/Inflector/Inflector.php
+++ b/src/Inflector/Inflector.php
@@ -2,9 +2,9 @@
 
 namespace League\Container\Inflector;
 
-use League\Container\ContainerAwareTrait;
 use League\Container\Argument\ArgumentResolverInterface;
 use League\Container\Argument\ArgumentResolverTrait;
+use League\Container\ContainerAwareTrait;
 
 class Inflector implements ArgumentResolverInterface, InflectorInterface
 {
@@ -17,7 +17,7 @@ class Inflector implements ArgumentResolverInterface, InflectorInterface
     protected $type;
 
     /**
-     * @var callable
+     * @var callable|null
      */
     protected $callback;
 
@@ -113,7 +113,7 @@ class Inflector implements ArgumentResolverInterface, InflectorInterface
             call_user_func_array([$object, $method], $args);
         }
 
-        if (! is_null($this->callback)) {
+        if ($this->callback !== null) {
             call_user_func_array($this->callback, [$object]);
         }
     }

--- a/src/Inflector/InflectorAggregate.php
+++ b/src/Inflector/InflectorAggregate.php
@@ -10,7 +10,7 @@ class InflectorAggregate implements InflectorAggregateInterface
     use ContainerAwareTrait;
 
     /**
-     * @var \League\Container\Inflector[]
+     * @var \League\Container\Inflector\Inflector[]
      */
     protected $inflectors = [];
 

--- a/src/ReflectionContainer.php
+++ b/src/ReflectionContainer.php
@@ -98,7 +98,7 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
             return $reflection->invokeArgs($callable, $this->reflectArguments($reflection, $args));
         }
 
-        $reflection = new ReflectionFunction($callable);
+        $reflection = new ReflectionFunction(\Closure::fromCallable($callable));
 
         return $reflection->invokeArgs($this->reflectArguments($reflection, $args));
     }


### PR DESCRIPTION
Phpstan requires PHP 7.1 so in order to save some pain with getting Travis CI to run tests for PHP 7.0 I opted to just bump the minimum required version.

Some minor code changes were required to make phpstan happy:
* manually indicate that some callables are callable and not `[array, mixed]`
* the usual handling of  `array|false` that never happens in practice