### PR TITLE
Problem with Reflection of unresolvable-but-optional arguments

### DIFF
--- a/src/Argument/ArgumentResolverTrait.php
+++ b/src/Argument/ArgumentResolverTrait.php
@@ -22,6 +22,15 @@ trait ArgumentResolverTrait
                 continue;
             }
 
+            if ($arg instanceof ClassNameWithOptionalValue) {
+                $optionalValue = $arg->getOptionalValue();
+                $optionalValueExists = true;
+                $arg = $arg->getValue();
+            } else {
+                $optionalValue = null;
+                $optionalValueExists = false;
+            }
+
             if ($arg instanceof ClassNameInterface) {
                 $arg = $arg->getValue();
             }
@@ -49,6 +58,8 @@ trait ArgumentResolverTrait
                 }
 
                 continue;
+            } elseif ($optionalValueExists) {
+                $arg = $optionalValue;
             }
         }
 
@@ -69,11 +80,16 @@ trait ArgumentResolverTrait
             }
 
             if ($class !== null) {
-                return $class->getName();
+                if ($param->isDefaultValueAvailable()) {
+                    return new ClassNameWithOptionalValue($class->getName(), $param->getDefaultValue());
+                }
+
+                return new ClassName($class->getName());
             }
 
             if ($param->isDefaultValueAvailable()) {
                 return $param->getDefaultValue();
+                //return new RawArgument($param->getDefaultValue());
             }
 
             throw new NotFoundException(sprintf(

--- a/src/Argument/ClassName.php
+++ b/src/Argument/ClassName.php
@@ -22,7 +22,7 @@ class ClassName implements ClassNameInterface
     /**
      * {@inheritdoc}
      */
-    public function getValue() : string
+    public function getClassName() : string
     {
         return $this->value;
     }

--- a/src/Argument/ClassNameInterface.php
+++ b/src/Argument/ClassNameInterface.php
@@ -9,5 +9,5 @@ interface ClassNameInterface
      *
      * @return string
      */
-    public function getValue() : string;
+    public function getClassName() : string;
 }

--- a/src/Argument/ClassNameWithOptionalValue.php
+++ b/src/Argument/ClassNameWithOptionalValue.php
@@ -7,7 +7,7 @@ class ClassNameWithOptionalValue implements ClassNameInterface
     /**
      * @var string
      */
-    private $value;
+    private $className;
 
     /**
      * @var mixed
@@ -15,23 +15,21 @@ class ClassNameWithOptionalValue implements ClassNameInterface
     private $optionalValue;
 
     /**
-     * Construct.
-     *
-     * @param string $value
+     * @param string $className
      * @param mixed $optionalValue
      */
-    public function __construct(string $value, $optionalValue)
+    public function __construct(string $className, $optionalValue)
     {
-        $this->value = $value;
+        $this->className = $className;
         $this->optionalValue = $optionalValue;
     }
 
     /**
      * @inheritDoc
      */
-    public function getValue(): string
+    public function getClassName(): string
     {
-        return $this->value;
+        return $this->className;
     }
 
     public function getOptionalValue()

--- a/src/Argument/ClassNameWithOptionalValue.php
+++ b/src/Argument/ClassNameWithOptionalValue.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace League\Container\Argument;
+
+class ClassNameWithOptionalValue implements ClassNameInterface
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @var mixed
+     */
+    private $optionalValue;
+
+    /**
+     * Construct.
+     *
+     * @param string $value
+     * @param mixed $optionalValue
+     */
+    public function __construct(string $value, $optionalValue)
+    {
+        $this->value = $value;
+        $this->optionalValue = $optionalValue;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function getOptionalValue()
+    {
+        return $this->optionalValue;
+    }
+}

--- a/src/Definition/Definition.php
+++ b/src/Definition/Definition.php
@@ -205,7 +205,7 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
         }
 
         if ($concrete instanceof ClassNameInterface) {
-            $concrete = $concrete->getValue();
+            $concrete = $concrete->getClassName();
         }
 
         if (is_string($concrete) && class_exists($concrete)) {

--- a/tests/Argument/ArgumentResolverTest.php
+++ b/tests/Argument/ArgumentResolverTest.php
@@ -3,7 +3,8 @@
 namespace League\Container\Test;
 
 use League\Container\Argument\{ArgumentResolverInterface, ArgumentResolverTrait, RawArgument};
-use League\Container\{Container, ContainerAwareTrait, ReflectionContainer, Test\Asset\Qux};
+use League\Container\{Container, ContainerAwareTrait};
+use League\Container\Test\Asset\Qux;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
 use ReflectionClass;

--- a/tests/Argument/ArgumentResolverTest.php
+++ b/tests/Argument/ArgumentResolverTest.php
@@ -3,7 +3,7 @@
 namespace League\Container\Test;
 
 use League\Container\Argument\{ArgumentResolverInterface, ArgumentResolverTrait, RawArgument};
-use League\Container\{Container, ContainerAwareTrait};
+use League\Container\{Container, ContainerAwareTrait, ReflectionContainer, Test\Asset\Qux};
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
 use ReflectionClass;
@@ -125,5 +125,20 @@ class ArgumentResolverTest extends TestCase
         };
 
         $resolver->reflectArguments($method);
+    }
+
+    /**
+     * Asserts that null is given for a type argument which can't be resolved.
+     */
+    public function testResolvesClassWithOptionalTypedArgument()
+    {
+        $resolver = new class implements ArgumentResolverInterface {
+            use ArgumentResolverTrait;
+            use ContainerAwareTrait;
+        };
+
+        $result = $resolver->reflectArguments((new ReflectionClass(Qux::class))->getConstructor());
+
+        $this->assertSame([null], $result);
     }
 }

--- a/tests/Argument/ArgumentResolverTest.php
+++ b/tests/Argument/ArgumentResolverTest.php
@@ -50,7 +50,7 @@ class ArgumentResolverTest extends TestCase
         $container = $this->getMockBuilder(Container::class)->getMock();
 
         $container->expects($this->at(0))->method('has')->with($this->equalTo('alias1'))->willReturn(true);
-        $container->expects($this->at(1))->method('get')->with($this->equalTo('alias1'))->willReturn(new RawArgument('value1'));
+        $container->expects($this->at(1))->method('get')->with($this->equalTo('alias1'))->willReturn('value1');
 
         $resolver->setLeagueContainer($container);
 
@@ -86,9 +86,8 @@ class ArgumentResolverTest extends TestCase
 
         $method->expects($this->once())->method('getParameters')->willReturn([$param1, $param2, $param3]);
 
-        $container->expects($this->at(0))->method('has')->with($this->equalTo('Class'))->willReturn(false);
-        $container->expects($this->at(1))->method('has')->with($this->equalTo('value2'))->willReturn(false);
-        $container->expects($this->at(2))->method('has')->with($this->equalTo('value3'))->willReturn(false);
+        $container->expects($this->once())->method('has')->with($this->equalTo('Class'))->willReturn(true);
+        $container->expects($this->once())->method('get')->with($this->equalTo('Class'))->willReturn('classObject');
 
         $resolver = new class implements ArgumentResolverInterface {
             use ArgumentResolverTrait;
@@ -99,7 +98,7 @@ class ArgumentResolverTest extends TestCase
 
         $args = $resolver->reflectArguments($method, ['param3' => 'value3']);
 
-        $this->assertSame('Class', $args[0]);
+        $this->assertSame('classObject', $args[0]);
         $this->assertSame('value2', $args[1]);
         $this->assertSame('value3', $args[2]);
     }

--- a/tests/Argument/ClassNameTest.php
+++ b/tests/Argument/ClassNameTest.php
@@ -19,7 +19,7 @@ class ClassNameTest extends TestCase
 
         foreach ($arguments as $expected) {
             $argument = new ClassName($expected);
-            $this->assertSame($expected, $argument->getValue());
+            $this->assertSame($expected, $argument->getClassName());
         }
     }
 }

--- a/tests/Asset/Bar.php
+++ b/tests/Asset/Bar.php
@@ -2,7 +2,7 @@
 
 namespace League\Container\Test\Asset;
 
-class Bar
+class Bar implements BarInterface
 {
     protected $something;
 

--- a/tests/Asset/BarInterface.php
+++ b/tests/Asset/BarInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Container\Test\Asset;
+
+interface BarInterface
+{
+}

--- a/tests/Asset/Qux.php
+++ b/tests/Asset/Qux.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace League\Container\Test\Asset;
+
+class Qux
+{
+    public function __construct(BarInterface $bar = null)
+    {
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -212,7 +212,7 @@ class ContainerTest extends TestCase
         $provider = new class extends AbstractServiceProvider
         {
             protected $provides = [
-                Foo::class
+                Foo::class,
             ];
 
             public function register()
@@ -221,7 +221,7 @@ class ContainerTest extends TestCase
             }
         };
 
-        $container = new Container;
+        $container = new Container();
 
         $container->addServiceProvider($provider);
 
@@ -237,7 +237,7 @@ class ContainerTest extends TestCase
     {
         $this->expectException(NotFoundException::class);
 
-        $container = new Container;
+        $container = new Container();
 
         $this->assertFalse($container->has(Foo::class));
 
@@ -249,7 +249,7 @@ class ContainerTest extends TestCase
      */
     public function testContainerAddsAndInvokesInflector()
     {
-        $container = new Container;
+        $container = new Container();
 
         $container->inflector(Foo::class)->setProperty('bar', Bar::class);
 

--- a/tests/ReflectionContainerTest.php
+++ b/tests/ReflectionContainerTest.php
@@ -4,7 +4,7 @@ namespace League\Container\Test;
 
 use League\Container\Exception\NotFoundException;
 use League\Container\ReflectionContainer;
-use League\Container\Test\Asset\{Foo, FooCallable, Bar, Qux};
+use League\Container\Test\Asset\{Foo, FooCallable, Bar};
 use PHPUnit\Framework\TestCase;
 use League\Container\Container;
 

--- a/tests/ReflectionContainerTest.php
+++ b/tests/ReflectionContainerTest.php
@@ -4,7 +4,7 @@ namespace League\Container\Test;
 
 use League\Container\Exception\NotFoundException;
 use League\Container\ReflectionContainer;
-use League\Container\Test\Asset\{Foo, FooCallable, Bar};
+use League\Container\Test\Asset\{Foo, FooCallable, Bar, Qux};
 use PHPUnit\Framework\TestCase;
 use League\Container\Container;
 
@@ -73,7 +73,7 @@ class ReflectionContainerTest extends TestCase
     }
 
     /**
-     * Asserts that ReflectionContainer instantiates and cacheds a class that does not have a constructor.
+     * Asserts that ReflectionContainer instantiates and caches a class that does not have a constructor.
      */
     public function testContainerInstantiatesAndCachesClassWithoutConstructor()
     {


### PR DESCRIPTION
when auto resolving a class with reflection, and the constructor has a param which isn't resolvable, but optional, then use the optional value instead of the type of the argument.

```
1) League\Container\Test\ReflectionContainerTest::testResolvesClassWithOptionalTypedArgument
TypeError: Argument 1 passed to League\Container\Test\Asset\Qux::__construct() must implement interface League\Container\Test\Asset\BarInterface or be null, string given
```