### PR TITLE
3.3.2 bug

### DIFF
--- a/tests/Argument/ArgumentResolverTest.php
+++ b/tests/Argument/ArgumentResolverTest.php
@@ -4,9 +4,10 @@ namespace League\Container\Test;
 
 use League\Container\Argument\{ArgumentResolverInterface, ArgumentResolverTrait, RawArgument};
 use League\Container\{Container, ContainerAwareTrait};
-use League\Container\Test\Asset\Qux;
+use League\Container\Test\Asset\{Qux, BarInterface};
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
+use ReflectionFunction;
 use ReflectionFunctionAbstract;
 use ReflectionParameter;
 use ReflectionType;
@@ -146,5 +147,18 @@ class ArgumentResolverTest extends TestCase
         $result = $resolver->reflectArguments((new \ReflectionClass(Qux::class))->getConstructor());
 
         $this->assertSame([null], $result);
+    }
+
+    public function testThrowsExceptionWhenUnresolvable()
+    {
+        $resolver = new class implements ArgumentResolverInterface {
+            use ArgumentResolverTrait;
+            use ContainerAwareTrait;
+        };
+
+        $resolver->setLeagueContainer(new Container());
+        $this->expectException(NotFoundExceptionInterface::class);
+
+        $resolver->reflectArguments(new ReflectionFunction(function (BarInterface $bar) {}));
     }
 }

--- a/tests/Argument/ArgumentResolverTest.php
+++ b/tests/Argument/ArgumentResolverTest.php
@@ -3,7 +3,7 @@
 namespace League\Container\Test;
 
 use League\Container\Argument\{ArgumentResolverInterface, ArgumentResolverTrait, RawArgument};
-use League\Container\{Container, ContainerAwareTrait};
+use League\Container\{Container, ContainerAwareTrait, Exception\NotFoundException};
 use League\Container\Test\Asset\{Qux, BarInterface};
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
@@ -25,16 +25,17 @@ class ArgumentResolverTest extends TestCase
         };
 
         $container = $this->getMockBuilder(Container::class)->getMock();
+        $exception = new NotFoundException();
 
-        $container->expects($this->at(0))->method('has')->with($this->equalTo('alias1'))->willReturn(true);
-        $container->expects($this->at(1))->method('get')->with($this->equalTo('alias1'))->willReturn($resolver);
-        $container->expects($this->at(2))->method('has')->with($this->equalTo('alias2'))->willReturn(false);
+        //$container->expects($this->at(0))->method('has')->with($this->equalTo('alias1'))->willReturn(true);
+        $container->expects($this->at(0))->method('get')->with($this->equalTo('alias1'))->willReturn('concrete1');
+        $container->expects($this->at(1))->method('get')->with($this->equalTo('alias2'))->willThrowException($exception);
 
         $resolver->setLeagueContainer($container);
 
         $args = $resolver->resolveArguments(['alias1', 'alias2']);
 
-        $this->assertSame($resolver, $args[0]);
+        $this->assertSame('concrete1', $args[0]);
         $this->assertSame('alias2', $args[1]);
     }
 
@@ -50,8 +51,7 @@ class ArgumentResolverTest extends TestCase
 
         $container = $this->getMockBuilder(Container::class)->getMock();
 
-        $container->expects($this->at(0))->method('has')->with($this->equalTo('alias1'))->willReturn(true);
-        $container->expects($this->at(1))->method('get')->with($this->equalTo('alias1'))->willReturn('value1');
+        $container->expects($this->once())->method('get')->with($this->equalTo('alias1'))->willReturn('value1');
 
         $resolver->setLeagueContainer($container);
 

--- a/tests/Definition/DefinitionTest.php
+++ b/tests/Definition/DefinitionTest.php
@@ -77,7 +77,6 @@ class DefinitionTest extends TestCase
 
         $bar = new Bar;
 
-        $container->expects($this->once())->method('has')->with($this->equalTo(Bar::class))->willReturn(true);
         $container->expects($this->once())->method('get')->with($this->equalTo(Bar::class))->willReturn($bar);
 
         $definition = new Definition('callable', Foo::class);
@@ -100,7 +99,6 @@ class DefinitionTest extends TestCase
 
         $bar = new Bar;
 
-        $container->expects($this->once())->method('has')->with($this->equalTo(Bar::class))->willReturn(true);
         $container->expects($this->once())->method('get')->with($this->equalTo(Bar::class))->willReturn($bar);
 
         $definition = new Definition('callable', Foo::class);
@@ -123,7 +121,6 @@ class DefinitionTest extends TestCase
 
         $bar = new Bar;
 
-        $container->expects($this->once())->method('has')->with($this->equalTo(Bar::class))->willReturn(true);
         $container->expects($this->once())->method('get')->with($this->equalTo(Bar::class))->willReturn($bar);
 
         $definition = new Definition('callable', new ClassName(Foo::class));

--- a/tests/Inflector/InflectorTest.php
+++ b/tests/Inflector/InflectorTest.php
@@ -2,6 +2,7 @@
 
 namespace League\Container\Test\Inflector;
 
+use League\Container\Exception\NotFoundException;
 use League\Container\Inflector\Inflector;
 use PHPUnit\Framework\TestCase;
 use League\Container\Container;
@@ -43,21 +44,24 @@ class InflectorTest extends TestCase
         $container = $this->getMockBuilder(Container::class)->getMock();
         $inflector = (new Inflector('Type'))->setLeagueContainer($container);
 
+        $exception = new NotFoundException();
+        $container->expects($this->exactly(3))->method('get')->with('value')->willThrowException($exception);
+
         $inflector->setProperty('property1', 'value');
 
         $inflector->setProperties([
             'property2' => 'value',
-            'property3' => 'value'
+            'property3' => 'value',
         ]);
 
         $properties = (new ReflectionClass($inflector))->getProperty('properties');
         $properties->setAccessible(true);
 
-        $this->assertSame($properties->getValue($inflector), [
+        $this->assertEquals([
             'property1' => 'value',
             'property2' => 'value',
-            'property3' => 'value'
-        ]);
+            'property3' => 'value',
+        ], $properties->getValue($inflector));
     }
 
     /**
@@ -70,8 +74,7 @@ class InflectorTest extends TestCase
         $bar = new class {
         };
 
-        $container->expects($this->once())->method('has')->with($this->equalTo('League\Container\Test\Asset\Bar'))->willReturn(true);
-        $container->expects($this->once())->method('get')->with($this->equalTo('League\Container\Test\Asset\Bar'))->willReturn($bar);
+        $container->expects($this->once())->method('get')->with(Bar::class)->willReturn($bar);
 
         $inflector = (new Inflector('Type'))
             ->setLeagueContainer($container)
@@ -97,7 +100,6 @@ class InflectorTest extends TestCase
         $bar = new class {
         };
 
-        $container->expects($this->once())->method('has')->with($this->equalTo('League\Container\Test\Asset\Bar'))->willReturn(true);
         $container->expects($this->once())->method('get')->with($this->equalTo('League\Container\Test\Asset\Bar'))->willReturn($bar);
 
         $inflector = (new Inflector('Type'))


### PR DESCRIPTION
For some reason I created an even worse bug in 3.3.2 (#206)

```php
$container = new ReflectionContainer();
$container->call(fn (FooInterface) => null);
```

would call that anonymous function with a `League\Container\Argument\ClassName` object.

```
Fatal error: Uncaught TypeError: Argument 1 passed to {closure}() must implement interface FooInterface, instance of League\Container\Argument\ClassName given
```