### PR TITLE
Fix recursive register() on ServiceProviderAggregate

### DIFF
--- a/src/ServiceProvider/ServiceProviderAggregate.php
+++ b/src/ServiceProvider/ServiceProviderAggregate.php
@@ -98,8 +98,8 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
             }
 
             if ($provider->provides($service)) {
-                $provider->register();
                 $this->registered[] = $provider->getIdentifier();
+                $provider->register();
             }
         }
     }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -230,6 +230,44 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(DefinitionInterface::class, $definition);
     }
 
+    public function testContainerCanExtendDefinitionInServiceProviderFromAnotherServiceProvider()
+    {
+        $providerA = new class extends AbstractServiceProvider
+        {
+            protected $provides = [
+                Foo::class,
+            ];
+
+            public function register()
+            {
+                $this->getLeagueContainer()->add(Foo::class);
+            }
+        };
+
+        $providerB = new class extends AbstractServiceProvider
+        {
+            protected $provides = [
+                Foo::class,
+            ];
+
+            public function register()
+            {
+                $this->getLeagueContainer()
+                    ->extend(Foo::class)
+                    ->addMethodCall('setBar', [new Bar()]);
+            }
+        };
+
+        $container = new Container();
+
+        $container->addServiceProvider($providerA);
+        $container->addServiceProvider($providerB);
+
+        $instance = $container->get(Foo::class);
+
+        $this->assertNotNull($instance->bar);
+    }
+
     /**
      * Asserts that the container throws an exception when can't find definition to extend.
      */


### PR DESCRIPTION
This MR aims to address issue #219 where an accidental recursive call to the `register()` method of the ServiceProviderAggregate was happening.

It contains 2 commits, the first being the test to prove the issue was happening and the scenario that triggered it and the second is the actual fix.

Happy to provide any more clarification if needed.