### PR TITLE
Handle non-public constructors safely

### DIFF
--- a/src/ReflectionContainer.php
+++ b/src/ReflectionContainer.php
@@ -47,6 +47,12 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
         $reflector = new ReflectionClass($id);
         $construct = $reflector->getConstructor();
 
+        if ($construct && !$construct->isPublic()) {
+            throw new NotFoundException(
+                sprintf('Alias (%s) has a non-public constructor and therefore cannot be instantiated', $id)
+            );
+        }
+
         $resolution = $construct === null
             ? new $id
             : $resolution = $reflector->newInstanceArgs($this->reflectArguments($construct, $args))

--- a/tests/Asset/ProBar.php
+++ b/tests/Asset/ProBar.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace League\Container\Test\Asset;
+
+class ProBar implements BarInterface
+{
+    protected function __construct()
+    {
+    }
+
+    public static function factory()
+    {
+        return new self;
+    }
+}

--- a/tests/Asset/ProFoo.php
+++ b/tests/Asset/ProFoo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace League\Container\Test\Asset;
+
+class ProFoo
+{
+    public $bar;
+
+    public function __construct(ProBar $bar = null)
+    {
+        $this->bar = $bar;
+    }
+}

--- a/tests/ReflectionContainerTest.php
+++ b/tests/ReflectionContainerTest.php
@@ -4,7 +4,7 @@ namespace League\Container\Test;
 
 use League\Container\Exception\NotFoundException;
 use League\Container\ReflectionContainer;
-use League\Container\Test\Asset\{Foo, FooCallable, Bar};
+use League\Container\Test\Asset\{Foo, FooCallable, Bar, ProBar, ProFoo};
 use PHPUnit\Framework\TestCase;
 use League\Container\Container;
 
@@ -152,6 +152,43 @@ class ReflectionContainerTest extends TestCase
 
         $this->assertInstanceOf($classWithConstructor, $item);
         $this->assertSame($dependency, $item->bar);
+    }
+
+    /**
+     * Asserts that ReflectionContainer instantiates a class that has a constructor with a type-hinted argument, and
+     * skips fetching that dependency from the ReflectionContainer due to a protected constructor.
+     */
+    public function testGetInstantiatesClassWithConstructorAndSkipsProtectedConstructor()
+    {
+        $classWithConstructor = ProFoo::class;
+
+        $container = new Container();
+        $container->delegate(new ReflectionContainer());
+
+        $item = $container->get($classWithConstructor);
+
+        $this->assertInstanceOf($classWithConstructor, $item);
+        $this->assertNull($item->bar);
+    }
+
+    /**
+     * Asserts that ReflectionContainer instantiates a class that has a constructor with a type-hinted argument, and
+     * uses the specified factory method due to the protected constructor.
+     */
+    public function testGetInstantiatesClassWithConstructorAndUsesFactory()
+    {
+        $classWithConstructor = ProFoo::class;
+        $dependencyClass      = ProBar::class;
+
+        $container = new Container();
+        $container->delegate(new ReflectionContainer());
+
+        $container->add($dependencyClass, [$dependencyClass, 'factory']);
+
+        $item = $container->get($classWithConstructor);
+
+        $this->assertInstanceOf($classWithConstructor, $item);
+        $this->assertInstanceOf($dependencyClass, $item->bar);
     }
 
     /**


### PR DESCRIPTION
When autowiring classes that declare default values in their constructor, ReflectionContainer always tries to `new` up an instance of the typehinted class.

If the constructor is `private` or `protected`, this fails - fatally.

By throwing a `NotFoundException`, the Container will instead use the default value of `null`.

This issue came up because I have some service classes that depend on protected-constructor classes, and those protected-constructor classes require a call to a factory method in order to be instantiated safely. Inside the constructor of the service classes, the `null` is checked & the factory method is called to populate a default instance.