### PR TITLE
Upgrade PHPUnit to ^7.0 (7.5.20)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^7.0",
         "roave/security-advisories": "dev-master",
         "scrutinizer/ocular": "^1.8",
         "squizlabs/php_codesniffer": "^3.5"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>


### PR DESCRIPTION
PHPUnit 6.x was causing a lot of `E` test results because of a deprecation notice on `ReflectionType::__toString()`, which appears to be used internally in its mocking library.

This PR updates to PHPUnit 7.0 (defaulting to 7.5.20 on my system), which doesn't have the issue.

This may result in a slight BC break of being unable to run the tests on PHP 7.0.x, but I can't test that locally. Perhaps the github actions matrix will reveal if that is an issue of concern.