### PR TITLE
Fix test file loading.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,15 +41,15 @@
     "autoload": {
         "psr-4": {
             "League\\Container\\": "src"
-        },
-        "files": [
-            "tests/Asset/function.php"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {
             "League\\Container\\Test\\": "tests"
-        }
+        },
+        "files": [
+            "tests/Asset/function.php"
+        ]        
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
It belongs under `autoload-dev` instead of `autoload`.

Currently running the testsuite of a project which has `league/container` as a dependency causes an error to be thrown since `tests/` is not included in zip archives through `.gitattributes`.

```
PHP Warning:  require(/somepath/vendor/composer/../league/container/tests/Asset/function.php): Failed to open stream: No such file or directory
```