### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
                 include:
                     - php: '8.0'
                       coverage: false
-                      composer-flags: '--ignore-platform-req=php'
                     - php: '7.2'
                       coverage: false
                       composer-flags: '--prefer-lowest'


### PR DESCRIPTION
Ignoring platform requirements should no longer be necessary for PHP 8.