### PR TITLE
Allow installation with psr/container 1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "psr/container": "^1.0.0 || ^2.0.0"
+        "psr/container": "^1.1 || ^2.0"
     },
     "require-dev": {
         "nette/php-generator": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "psr/container": "^2.0.0"
+        "psr/container": "^1.0.0 || ^2.0.0"
     },
     "require-dev": {
         "nette/php-generator": "^3.4",


### PR DESCRIPTION
With #226 it was possible to use league/container with `"psr/container": "^1.0.0 || ^2.0.0"`, but while releasing v4, the requirement was changed to `"psr/container": "^2.0.0"`, see https://github.com/thephpleague/container/commit/67cba1a184e9ebbf082e37d3c9337e755a90a58f

I couldn't find any reason why this was made and I propose to bring the compatibilty with `"psr/container": "^1.0.0 || ^2.0.0"` back again.

The main reason is, that Symfony 5.4 (LTS) will only allow `"psr/container": "^1.0.0"` for BC reasons. Starting with Symfony 6.0 (not LTS) it will be possible to use `"psr/container": "^1.0.0 || ^2.0.0"`, see https://github.com/symfony/symfony/issues/42683.
The next LTS version will be Symfony 6.4 and will be released November 2023. I would like to follow the LTS path, and this means that I cannot update to league/container v4 until Nov 2023.

This PR would allow to use both Symfony 5.4 and league/container 4 today.