### PR TITLE
Fix mistake in "Auto Wiring" documentation

### DIFF
--- a/docs/4.x/auto-wiring.md
+++ b/docs/4.x/auto-wiring.md
@@ -124,7 +124,7 @@ $container = new League\Container\Container();
 
 // register the reflection container as a delegate to enable auto wiring
 $container->delegate(
-    (new League\Container\ReflectionContainer())->cacheResolutions()
+    new League\Container\ReflectionContainer(true)
 );
 
 $fooOne = $container->get(Acme\Foo::class);


### PR DESCRIPTION
Update "Auto Wiring" documentation to reflect removal of `cacheResolutions` method in `ReflectionContainer`