### PR TITLE
Adds template annotations so IDEs can autocomplete the referenced class

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -106,11 +106,25 @@ class Container implements DefinitionContainerInterface
         return $this;
     }
 
+    /**
+     * @template RequestedType
+     *
+     * @param class-string<RequestedType>|string $id
+     *
+     * @return RequestedType|mixed
+     */
     public function get($id)
     {
         return $this->resolve($id);
     }
 
+    /**
+     * @template RequestedType
+     *
+     * @param class-string<RequestedType>|string $id
+     *
+     * @return RequestedType|mixed
+     */
     public function getNew($id)
     {
         return $this->resolve($id, true);


### PR DESCRIPTION
This pull request adds [template annotations](https://psalm.dev/docs/annotating_code/templated_annotations/) to the container so an IDE can understand that the `get` and `getNew` methods return an instance of the requested class when the `$id` parameter is a class FQDN.

For example, an IDE such as PhpStorm will be able to autocomplete `DateTime` methods on the following:

```PHP

$container = new Container();

$date = $container->get(DateTime::class);

```

I recognize this may be somewhat trivial, but I have found it helpful elsewhere.