### PR TITLE
Handle preceeding slash in class name handling

### DIFF
--- a/src/Definition/Definition.php
+++ b/src/Definition/Definition.php
@@ -61,6 +61,8 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
      */
     public function __construct(string $id, $concrete = null)
     {
+        $id = Util::normalizeAlias($id);
+
         $concrete = $concrete ?? $id;
         $this->alias    = $id;
         $this->concrete = $concrete;
@@ -79,6 +81,8 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
 
     public function setAlias(string $id): DefinitionInterface
     {
+        $id = Util::normalizeAlias($id);
+
         $this->alias = $id;
         return $this;
     }

--- a/src/Definition/DefinitionAggregate.php
+++ b/src/Definition/DefinitionAggregate.php
@@ -26,8 +26,6 @@ class DefinitionAggregate implements DefinitionAggregateInterface
 
     public function add(string $id, $definition): DefinitionInterface
     {
-		$id = Util::normalizeAlias($id);
-
         if (false === ($definition instanceof DefinitionInterface)) {
             $definition = new Definition($id, $definition);
         }

--- a/src/Definition/DefinitionAggregate.php
+++ b/src/Definition/DefinitionAggregate.php
@@ -26,6 +26,8 @@ class DefinitionAggregate implements DefinitionAggregateInterface
 
     public function add(string $id, $definition): DefinitionInterface
     {
+		$id = Util::normalizeAlias($id);
+
         if (false === ($definition instanceof DefinitionInterface)) {
             $definition = new Definition($id, $definition);
         }
@@ -43,6 +45,8 @@ class DefinitionAggregate implements DefinitionAggregateInterface
 
     public function has(string $id): bool
     {
+        $id = Util::normalizeAlias($id);
+
         foreach ($this->getIterator() as $definition) {
             if ($id === $definition->getAlias()) {
                 return true;
@@ -65,6 +69,8 @@ class DefinitionAggregate implements DefinitionAggregateInterface
 
     public function getDefinition(string $id): DefinitionInterface
     {
+        $id = Util::normalizeAlias($id);
+
         foreach ($this->getIterator() as $definition) {
             if ($id === $definition->getAlias()) {
                 return $definition->setContainer($this->getContainer());

--- a/src/Definition/Util.php
+++ b/src/Definition/Util.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Container\Definition;
+
+class Util
+{
+    public static function normalizeAlias(string $alias): string
+    {
+        return $alias;
+    }
+}

--- a/src/Definition/Util.php
+++ b/src/Definition/Util.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace League\Container\Definition;
 

--- a/src/Definition/Util.php
+++ b/src/Definition/Util.php
@@ -8,6 +8,10 @@ class Util
 {
     public static function normalizeAlias(string $alias): string
     {
+        if (strpos($alias, '\\') === 0) {
+            return substr($alias, 1);
+        }
+
         return $alias;
     }
 }

--- a/src/Definition/Util.php
+++ b/src/Definition/Util.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace League\Container\Definition;
 

--- a/tests/Definition/DefinitionAggregateTest.php
+++ b/tests/Definition/DefinitionAggregateTest.php
@@ -242,4 +242,18 @@ class DefinitionAggregateTest extends TestCase
 
         self::assertInstanceOf(Definition::class, $definition);
     }
+
+    public function testGetPreceedingSlash(): void
+    {
+        $container   = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate   = new DefinitionAggregate();
+        $aggregate->setContainer($container);
+
+        $some_class = Foo::class;
+        $aggregate->add($some_class, null);
+
+        $definition = $aggregate->getDefinition("\\League\\Container\\Test\\Asset\\Foo");
+
+        self::assertInstanceOf(Definition::class, $definition);
+    }
 }

--- a/tests/Definition/DefinitionAggregateTest.php
+++ b/tests/Definition/DefinitionAggregateTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace League\Container\Test\Definition;
 
 use League\Container\Container;
-use League\Container\Definition\{DefinitionAggregate, DefinitionInterface};
+use League\Container\Definition\{Definition, DefinitionAggregate, DefinitionInterface};
 use League\Container\Exception\NotFoundException;
 use League\Container\Test\Asset\Foo;
 use PHPUnit\Framework\TestCase;
@@ -227,5 +227,19 @@ class DefinitionAggregateTest extends TestCase
         $aggregate->addShared('alias2', $definition2);
 
         $aggregate->resolveNew('alias');
+    }
+
+    public function testDefinitionPreceedingSlash(): void
+    {
+        $container   = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate   = new DefinitionAggregate();
+        $aggregate->setContainer($container);
+
+        $some_class = "\\League\\Container\\Test\\Asset\\Foo";
+        $aggregate->add($some_class, null);
+
+        $definition = $aggregate->getDefinition(Foo::class);
+
+        self::assertInstanceOf(Definition::class, $definition);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/thephpleague/container/issues/237

To summarise that issue:

* PHP class names may be valid in both the format `Foo\Bar` and also as `\Foo\Bar` when used as a string
* Using `Foo::class` returns `Foo\Bar` but legitimate user code may handle as `\Foo\Bar` and this would work for `class_exists` or `new $var` cases
* Because of this, a concrete class may be set with one form of slash, and got with the other. This means the set definition is not used.
* This fix adds test for both ways round that this issue could occur, and implements the class name normalizing in each appropriate place

This aims to be backwards compatible and causes no test failures.