### PR TITLE
Replace deprecated getClass function with getType

### DIFF
--- a/src/Argument/ArgumentResolverTrait.php
+++ b/src/Argument/ArgumentResolverTrait.php
@@ -51,14 +51,23 @@ trait ArgumentResolverTrait
     {
         $arguments = array_map(function (ReflectionParameter $param) use ($method, $args) {
             $name  = $param->getName();
-            $class = $param->getClass();
+            $type = $param->getType();
 
             if (array_key_exists($name, $args)) {
                 return $args[$name];
             }
 
-            if (! is_null($class)) {
-                return $class->getName();
+            if ($type) {
+                if (PHP_VERSION_ID >= 70100) {
+                    $typeName = $type->getName();
+                } else {
+                    $typeName = (string) $type;
+                }
+
+                // in PHP 8, nullable arguments have "?" prefix
+                $typeHint = ltrim($typeName, '?');
+
+                return $typeHint;
             }
 
             if ($param->isDefaultValueAvailable()) {


### PR DESCRIPTION
This change removes the deprecated warning for ReflectionParameter::getClass in PHP 8 and adds support for nullable arguments.

This change was taken from the 3.x branch.