### PR TITLE
ci: Use GitHub Actions V3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -38,7 +38,7 @@ jobs:
                       composer-flags: '--prefer-lowest'
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - uses: shivammathur/setup-php@v2
               with:


### PR DESCRIPTION
This PR updates the GitHub Actions from V2 to V3.

All annotated warning link to the official GitHub documentation: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/