### PR TITLE
Add mixed as a return type

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -113,7 +113,7 @@ class Container implements DefinitionContainerInterface
      *
      * @return RequestedType|mixed
      */
-    public function get($id)
+    public function get($id): mixed
     {
         return $this->resolve($id);
     }

--- a/src/ReflectionContainer.php
+++ b/src/ReflectionContainer.php
@@ -32,7 +32,7 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
         $this->cacheResolutions = $cacheResolutions;
     }
 
-    public function get($id, array $args = [])
+    public function get($id, array $args = []): mixed
     {
         if ($this->cacheResolutions === true && array_key_exists($id, $this->cache)) {
             return $this->cache[$id];


### PR DESCRIPTION
Add mixed as a return type since ContainerInterface might add that return type as well. This fix is to suppress warnings that popped up after upgrading to php8.2