### PR TITLE
Update README.md replacing Travis badge for Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Author](http://img.shields.io/badge/author-@philipobenito-blue.svg?style=flat-square)](https://twitter.com/philipobenito)
 [![Latest Version](https://img.shields.io/github/release/thephpleague/container.svg?style=flat-square)](https://github.com/thephpleague/container/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-[![Build Status](https://img.shields.io/travis/thephpleague/container/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/container)
+[![Tests](https://github.com/thephpleague/container/actions/workflows/test.yml/badge.svg)](https://github.com/thephpleague/container/actions/workflows/test.yml)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/thephpleague/container.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/container/code-structure)
 [![Quality Score](https://img.shields.io/scrutinizer/g/thephpleague/container.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/container)
 [![Total Downloads](https://img.shields.io/packagist/dt/league/container.svg?style=flat-square)](https://packagist.org/packages/league/container)


### PR DESCRIPTION
Since more than three years ago in a2ec537abad80c3f522d0a250fea2b800f47063e Travis was dropped and replaced with GitHub Actions. This PR replaces the badge acordingly.