### PR TITLE
Restore ability to perform recursive definition search

### DIFF
--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -214,7 +214,8 @@ class ContainerTest extends TestCase
     {
         $this->expectException(BadMethodCallException::class);
 
-        $class = new class {
+        $class = new class
+        {
             use ContainerAwareTrait;
         };
 
@@ -222,12 +223,13 @@ class ContainerTest extends TestCase
         $class->setContainer($container);
     }
 
-    public function testNonExistentClassCausesException(): void
+    public function testNonExistentClassIsReturnedAsIdenticalString(): void
     {
+        $nonExistent = NonExistent::class;
         $container = new Container();
-        $container->add(NonExistent::class);
+        $container->add($nonExistent);
 
-        self::assertTrue($container->has(NonExistent::class));
-        self::assertSame(NonExistent::class, $container->get(NonExistent::class));
+        self::assertTrue($container->has($nonExistent));
+        self::assertSame($nonExistent, $container->get($nonExistent));
     }
 }

--- a/tests/Definition/DefinitionTest.php
+++ b/tests/Definition/DefinitionTest.php
@@ -136,4 +136,13 @@ class DefinitionTest extends TestCase
         $definition->setConcrete($concrete);
         self::assertSame($concrete, $definition->getConcrete());
     }
+
+    public function testNonExistentClassIsReturnedAsIdenticalString(): void
+    {
+        $nonExistent = NonExistent::class;
+        $definition = new Definition($nonExistent);
+
+        self::assertSame($nonExistent, $definition->getAlias());
+        self::assertSame($nonExistent, $definition->resolve());
+    }
 }


### PR DESCRIPTION
This pull request maintains the newly added behavior of returning a string when when the concrete value is derived from a non-class alias while restoring the ability to resolve definitions recursively. Removing or limiting recursive resolution resulted in unresolvable definitions that were previously valid. The test has also been renamed to better reflect the expected behavior as well as added to `DefinitionTest` since the behavior exists on the `Definition` class.