### PR TITLE
Remove `never` return type on `BootableServiceProviderInterface::boot`.

### DIFF
--- a/src/ServiceProvider/BootableServiceProviderInterface.php
+++ b/src/ServiceProvider/BootableServiceProviderInterface.php
@@ -9,8 +9,6 @@ interface BootableServiceProviderInterface extends ServiceProviderInterface
     /**
      * Method will be invoked on registration of a service provider implementing
      * this interface. Provides ability for eager loading of Service Providers.
-     *
-     * @return never
      */
     public function boot(): void;
 }


### PR DESCRIPTION
The `boot` method is not meant to `never` return.

It is expected that the method, as stated in the documentation, provides the ability to eager load services.

Making this method throw would interrupt the startup of the container.
